### PR TITLE
Another fixes for assembler

### DIFF
--- a/cocas/code_block.py
+++ b/cocas/code_block.py
@@ -85,18 +85,20 @@ class CodeBlock:
         cond_location = line.cond_location
 
         next_or = 0
+        next_or_label = f'{or_label}{next_or}'
         for cond in line.conditions:
             self.assemble_lines(cond.lines, temp_storage)
-            next_or_label = f'{or_label}{next_or}'
             if cond.conjunction is None:
                 self.append_branch_instruction(cond_location, cond.branch_mnemonic, else_label, True)
             elif cond.conjunction == 'or':
                 self.append_branch_instruction(cond_location, cond.branch_mnemonic, then_label, False)
                 self.append_label(next_or_label)
                 next_or += 1
+                next_or_label = f'{or_label}{next_or}'
             elif cond.conjunction == 'and':
                 self.append_branch_instruction(cond_location, cond.branch_mnemonic, next_or_label, True)
 
+        self.append_label(next_or_label)
         self.append_label(then_label)
         self.assemble_lines(line.then_lines, temp_storage)
 

--- a/cocas/targets/cdm16/code_segments.py
+++ b/cocas/targets/cdm16/code_segments.py
@@ -204,7 +204,8 @@ class CodeSegments(CodeSegmentsInterface):
                     _error(self, 'Cannot subtract labels in branch value expressions')
                 elif len(self.expr.add_terms) > 1:
                     _error(self, 'Cannot use multiple labels in branch value expressions')
-                bad = self.parsed.external or self.parsed.asect and section.name != '$abs'
+                const = not self.expr.add_terms and not self.expr.sub_terms
+                bad = self.parsed.external or (self.parsed.asect or const) and section.name != '$abs'
                 self.checked = True
             value = CodeSegments.calculate_expression(self.parsed, section, labels)
             dist = value - pos - 2

--- a/cocas/targets/cdm16/target_instructions.py
+++ b/cocas/targets/cdm16/target_instructions.py
@@ -26,9 +26,19 @@ def assert_count_args(args, *types):
     assert_args(args, *types)
 
 
+def handle_frame_pointer(line: InstructionNode):
+    for i in range(len(line.arguments)):
+        arg = line.arguments[i]
+        if isinstance(arg, RelocatableExpressionNode):
+            if not arg.const_term and not arg.sub_terms and not arg.byte_specifier and len(arg.add_terms) == 1 \
+                    and isinstance(arg.add_terms[0], LabelNode) and arg.add_terms[0].name == 'fp':
+                line.arguments[i] = RegisterNode(7)
+
+
 class TargetInstructions(TargetInstructionsInterface):
     @staticmethod
     def assemble_instruction(line: InstructionNode, temp_storage: dict) -> list[CodeSegmentsInterface.CodeSegment]:
+        handle_frame_pointer(line)
         try:
             for h in TargetInstructions.handlers:
                 if line.mnemonic in h.instructions:

--- a/cocas/targets/cdm16/target_instructions.py
+++ b/cocas/targets/cdm16/target_instructions.py
@@ -350,6 +350,10 @@ class TargetInstructions(TargetInstructionsInterface):
             arg.const_term //= 2
             return [CodeSegments.Imm9(line.location, False, 2, arg)]
         elif line.mnemonic == 'jsr':
+            if len(line.arguments) == 1 and isinstance(line.arguments[0], RegisterNode):
+                jsrr = copy(line)
+                jsrr.mnemonic = 'jsrr'
+                return TargetInstructions.assemble_instruction(jsrr, temp_storage)
             assert_count_args(line.arguments, RelocatableExpressionNode)
             return [CodeSegments.Branch(line.location, 0, line.arguments[0], operation='jsr')]
 

--- a/vscode-cdm-extension/syntaxes/cdm16-assembly.tmLanguage.json
+++ b/vscode-cdm-extension/syntaxes/cdm16-assembly.tmLanguage.json
@@ -71,7 +71,7 @@
 		"macros": {
 			"patterns": [{
 				"name": "keyword.control.instruction.cdm8-assembly",
-				"match": "\\b(else|if|fi|is|gt|lt|le|ge|mi|pl|eq|ne|z|nz|cs|cc|vs|vc|hi|lo|hs|ls|true|false|continue|wend|until|while|save|restore|stays|break|tst|clr|do|unique|rts|bis|inc|dec|ld|st|ldc|nop)\\b"
+				"match": "\\b(else|if|fi|is|gt|lt|le|ge|mi|pl|eq|ne|z|nz|cs|cc|vs|vc|hi|lo|hs|ls|true|false|continue|wend|until|while|save|restore|stays|break|tst|clr|do|then|unique|rts|bis|inc|dec|ld|st|ldc|nop)\\b"
 			}]
 		},
         "labels": {


### PR DESCRIPTION
- Fix #23 
- Fix branches onto constants (no labels) in relative sections became relative
- Add ability to name `r7` as `fp` (frame pointer)
- Add ability to call `jsr <register>`, shortcut to `jsrr`