### PR TITLE
Rework immediate value handling

### DIFF
--- a/cocas/targets/cdm16/code_segments.py
+++ b/cocas/targets/cdm16/code_segments.py
@@ -219,8 +219,9 @@ class CodeSegments(CodeSegmentsInterface):
         expr: RelocatableExpressionNode
 
         def __init__(self, location: CodeLocation, negative: bool, op_number: int, register: RegisterNode,
-                     expr: RelocatableExpressionNode):
+                     expr: RelocatableExpressionNode, word=False):
             super().__init__(location)
+            self.word = word
             self.op_number = op_number
             self.sign = -1 if negative else 1
             self.reg: int = register.number
@@ -236,7 +237,11 @@ class CodeSegments(CodeSegmentsInterface):
                 _error(self, 'No external labels allowed in immediate form')
             elif parsed.relative_additions != 0:
                 _error(self, 'Can use rsect labels only to find distance in immediate form')
-            elif not -64 <= value < 64:
+            if self.word:
+                if value % 2 != 0:
+                    _error(self, "Destination address must be 2-byte aligned")
+                value //= 2
+            if not -64 <= value < 64:
                 _error(self, 'Value is out of bounds for immediate form')
             object_record.data.extend(pack("u3u3s7u3", 0b011, self.op_number, value, self.reg))
 

--- a/cocas/targets/cdm16/target_instructions.py
+++ b/cocas/targets/cdm16/target_instructions.py
@@ -280,6 +280,11 @@ class TargetInstructions(TargetInstructionsInterface):
         return [CodeSegments.Imm6(line.location, False, op_number, *line.arguments)]
 
     @staticmethod
+    def imm6_word(line: InstructionNode, _, op_number: int) -> list[CodeSegmentsInterface.CodeSegment]:
+        assert_count_args(line.arguments, RegisterNode, RelocatableExpressionNode)
+        return [CodeSegments.Imm6(line.location, False, op_number, *line.arguments, word=True)]
+
+    @staticmethod
     def alu3(line: InstructionNode, _, op_number: int):
         if len(line.arguments) == 3:
             assert_args(line.arguments, RegisterNode, RegisterNode, RegisterNode)
@@ -383,7 +388,8 @@ class TargetInstructions(TargetInstructionsInterface):
         Handler(alu3_ind, {'bit': 0}),
         Handler(mem, {'ldw': 0, 'ldb': 1, 'ldsb': 2, 'lcw': 3, 'lcb': 4, 'lcsb': 5, 'stw': 6, 'stb': 7}),
         Handler(alu2, {'neg': 0, 'not': 1, 'sxt': 2, 'scl': 3}),
-        Handler(imm6, {'lsw': 0, 'lsb': 1, 'lssb': 2, 'ssw': 3, 'ssb': 4}),
+        Handler(imm6, {'lsb': 1, 'lssb': 2, 'ssb': 4}),
+        Handler(imm6_word, {'lsw': 0, 'ssw': 3}),
         Handler(alu3, {'and': 0, 'or': 1, 'xor': 2, 'bic': 3, 'addc': 5, 'subc': 7}),
         Handler(special, {'add': -1, 'sub': -1, 'cmp': -1, 'int': -1, 'reset': -1, 'addsp': -1, 'jsr': -1, 'push': -1})
     ]

--- a/docs/cdm16/cdm16-overview.md
+++ b/docs/cdm16/cdm16-overview.md
@@ -106,16 +106,21 @@ However, programmer should not exceed size of maximum available operand type.
 
 **Operations with frame pointer:**
 
-Processor can access data by adding a constant to **fp**. **Note:** in this case ***imm6*** represents number of 2-byte **words**.<br>
-*(so the resulting address is **fp + (imm6 * 2**))*.
+Processor can access data by adding a constant to **fp**. There, ***off*** is an immediate value, offset to **fp** in bytes.
+
+There are some limitations:
++ For **byte** variants: $-64 \leq off < 64$
++ For **word** variants: $-128 \leq off < 128$ and ***off*** must be **even**
+
+> **Note:** ***off*** will be expanded by assembler as ***off*** = ***imm6* \* *size***. This gives limitations above. 
 
 |              Instruction               |                     Description                       | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
 | :------------------------------------: | :---------------------------------------------------: | :-----------------: | :----------------: | :---------------: |
-| **lsw** ***rd***, ***imm6*** | **Load word from stack**. **-...-** | - | 1 | 2 |
-| **lsb** ***rd***, ***imm6*** | **Load byte from stack**. **-...-** | - | 1 | 2 |
-| **lssb** ***rd***, ***imm6*** | **Load signed byte from stack**. **-...-** | - | 1 | 2 |
-| **ssw** ***rd***, ***imm6*** | **Store word on stack**. **-...-** | - | 1 | 2 |
-| **ssb** ***rd***, ***imm6*** | **Store byte on stack**. **-...-** | - | 1 | 2 |
+| **lsw** ***rd***, ***off*** | **Load word relative to *fp***. Loads a word from memory locaton ***fp* + *off*** to ***rd***. | - | 1 | 2 |
+| **lsb** ***rd***, ***off*** | **Load byte relative to *fp***. Loads a byte from memory locaton ***fp* + *off*** to ***rd***. | - | 1 | 2 |
+| **lssb** ***rd***, ***off*** | **Load signed byte relative to *fp***. Loads a byte from memory<br>locaton ***fp* + *off*** to ***rd*** with sign-extend. | - | 1 | 2 |
+| **ssw** ***rd***, ***off*** | **Store word relative to *fp***. Stores a word from ***rd*** to memory locaton ***fp* + *off***. | - | 1 | 2 |
+| **ssb** ***rd***, ***off*** | **Store byte relative to *fp***. Stores a lower byte of ***rd*** to memory locaton ***fp* + *off***. | - | 1 | 2 |
 
 ### Flow control instructions:
 Asterisk *(\*)* in branch instuctions is a condition. It must be replaced with one of condition codes:

--- a/docs/cdm16/cdm16-overview.md
+++ b/docs/cdm16/cdm16-overview.md
@@ -236,7 +236,9 @@ bz # branch if r0 == 0
 | **bis** ***rs0***, ***rs1***, ***rd*** | **Bit set**. Sets bits in ***rs0*** that are set in ***rs1***. Computes ***rs0* \| *rs1*** and puts result in ***rd***. | **or** ***rs0***, ***rs1***, ***rd*** | 
 
 ### Shift instructions:
-**CdM-16** has a barrel shifter that can performs shifts from **1** to **8** postitions, ***val*** determines distance of shift.
+**CdM-16** has a barrel shifter that can perform shifts from **1** to **8** postitions, ***val*** is an immediate value that determines distance of shift. It can take values from **1** to **8**, ***val* == 0** is considered invalid.
+
+> **Note:** ***val*** will be expanded by assembler as ***val*** = ***imm3* + 1**. This gives limitations above. 
 
 + **Z, N** flags is set accoding to resulting number
 + **C** is set according to last shifted bit

--- a/docs/cdm16/cdm16-overview.md
+++ b/docs/cdm16/cdm16-overview.md
@@ -197,18 +197,18 @@ bz  # branch if r0 == 0
 
 ### Register transfer instructions:
 
-|          Instruction          |                                            Description                                             | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
-|:-----------------------------:|:--------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
-| **ldi** ***rd***, ***imm16*** |           **Load immediate to register**. Loads immediate value ***imm16*** to ***rd***.           |          -          |         1          |         4         |
-| **ldi** ***rd***, ***imm6***  |        **Load short immediate to register**. Loads immediate value ***imm6*** to ***rd***.         |          -          |         1          |         2         |
-|  **move** ***rs***, ***rd***  |                     **Copy register**. Copies value from ***rs*** to ***rd***.                     |     C, V, Z, N      |         1          |         2         |
-|     **addsp** ***imm9***      | **Add immediate to SP**. Adds ***imm9* * *2*** to **SP**. <br> (***imm9** is number of **words***) |          -          |         1          |         2         |
-|       **ldsp** ***rd***       |                         **Load SP**. Copies value from **SP** to ***rd***.                         |          -          |         1          |         2         |
-|       **stsp** ***rd***       |                        **Store SP**. Copies value from ***rd*** to **SP**.                         |          -          |         1          |         2         |
-|       **ldps** ***rd***       |                         **Load PS**. Copies value from **PS** to ***rd***.                         |          -          |         1          |         2         |
-|       **stps** ***rd***       |                        **Store PS**. Copies value from ***rd*** to **PS**.                         |          -          |         1          |         2         |
-|       **ldpc** ***rd***       |                         **Load PC**. Copies value from **PC** to ***rd***.                         |          -          |         1          |         2         |
-|       **stpc** ***rd***       |                        **Store PC**. Copies value from ***rd*** to **PC**.                         |          -          |         1          |         2         |
+|          Instruction          |                                                                    Description                                                                     | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
+|:-----------------------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
+| **ldi** ***rd***, ***imm16*** |                                   **Load immediate to register**. Loads immediate value ***imm16*** to ***rd***.                                   |          -          |         1          |         4         |
+| **ldi** ***rd***, ***imm6***  |                                **Load short immediate to register**. Loads immediate value ***imm6*** to ***rd***.                                 |          -          |         1          |         2         |
+|  **move** ***rs***, ***rd***  |                                             **Copy register**. Copies value from ***rs*** to ***rd***.                                             |     C, V, Z, N      |         1          |         2         |
+|      **addsp** ***val***      | **Add immediate to SP**. Adds ***val*** bytes to **SP**. <br> (***val*** is immediate value; $-1024 &leq; val < 1024$; ***val*** must be **even**) |          -          |         1          |         2         |
+|       **ldsp** ***rd***       |                                                 **Load SP**. Copies value from **SP** to ***rd***.                                                 |          -          |         1          |         2         |
+|       **stsp** ***rd***       |                                                **Store SP**. Copies value from ***rd*** to **SP**.                                                 |          -          |         1          |         2         |
+|       **ldps** ***rd***       |                                                 **Load PS**. Copies value from **PS** to ***rd***.                                                 |          -          |         1          |         2         |
+|       **stps** ***rd***       |                                                **Store PS**. Copies value from ***rd*** to **PS**.                                                 |          -          |         1          |         2         |
+|       **ldpc** ***rd***       |                                                 **Load PC**. Copies value from **PC** to ***rd***.                                                 |          -          |         1          |         2         |
+|       **stpc** ***rd***       |                                                **Store PC**. Copies value from ***rd*** to **PC**.                                                 |          -          |         1          |         2         |
 
 ### Processor control instructions:
 

--- a/docs/cdm16/cdm16-overview.md
+++ b/docs/cdm16/cdm16-overview.md
@@ -101,8 +101,8 @@ as `78 74` instead.*
 
 **Operations with stack:**
 
-+ When a **push** is performed, processor decrements **SP** by 2 bytes and stores data to memory pointed by new **SP
-  ** <br> *(resulting address is **SP-2**)*.
++ When a **push** is performed, processor decrements **SP** by 2 bytes and stores data to memory pointed by new
++ **SP** <br> *(resulting address is **SP-2**)*.
 + When a **pop** is performed, processor loads data from memory pointed by **SP** and then increments **SP** by 2 bytes.
 
 |     Instruction     |                                     Description                                      | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
@@ -124,10 +124,11 @@ bytes.
 
 There are some limitations:
 
-+ For **byte** variants: $-64 \leq off < 64$
-+ For **word** variants: $-128 \leq off < 128$ and ***off*** must be **even**
++ For **byte** variants: $-64 &leq; off < 64$
++ For **word** variants: $-128 &leq; off < 128$ and ***off*** must be **even**
 
-> **Note:** ***off*** will be expanded by assembler as ***off*** = ***imm6* \* *size***. This gives limitations above.
+> **Note:** ***off*** will be expanded by assembler as ***off*** = ***imm6* &ast; *size***. This gives limitations
+> above.
 
 |         Instruction          |                                                        Description                                                         | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
 |:----------------------------:|:--------------------------------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
@@ -139,7 +140,7 @@ There are some limitations:
 
 ### Flow control instructions:
 
-Asterisk *(\*)* in branch instructions is a condition. It must be replaced with one of condition codes:
+Asterisk *(&ast;)* in branch instructions is a condition. It must be replaced with one of condition codes:
 
 | Condition code |              Description              | 
 |:--------------:|:-------------------------------------:|
@@ -178,15 +179,15 @@ r0
 bz  # branch if r0 == 0
 ```
 
-|     Instruction     |                                                                         Description                                                                         | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
-|:-------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
-| **b\*** ***imm16*** |                **Absolute branch**. Loads ***imm16*** to **PC**, thus passing control to the instruction located at the address ***imm16***.                |          -          |         1          |         4         |
-| **b\*** ***imm9***  | **Relative branch**. Adds value ***imm9* \* *2*** to **PC**, thus passing control to the instruction located at the address **PC + (*imm9* \* *2*) + *2***. |          -          |         1          |         2         |
-| **jsr** ***imm16*** |             **Jump to subroutine (Absolute)**. Pushes **PC** to stack and then does unconditional <br> absolute branch to address ***imm16***.              |          -          |         2          |         4         |
-| **jsr** ***imm9***  |             **Jump to subroutine (Relative)**. Pushes **PC** to stack and then does unconditional <br> relative branch with offset ***imm9***.              |          -          |         2          |         2         |
-|  **jsrr** ***rd***  |        **Jump to subroutine by pointer**. Pushes **PC** to stack and then does unconditional <br> absolute branch to address contained in ***rd***.         |          -          |         2          |         2         |
-| **int** ***imm9***  |                                      **Software interrupt**. Triggers an interrupt with vector with number ***imm9***.                                      |          -          |         4          |         2         |
-|       **rti**       |             **Return from interrupt**. Pops **PC** and **PS** from stack and thus returns <br> control to the caller code and restores **PS**.              |          -          |         2          |         2         |
+|      Instruction       |                                                                            Description                                                                            | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
+|:----------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
+| **b&ast;** ***imm16*** |                   **Absolute branch**. Loads ***imm16*** to **PC**, thus passing control to the instruction located at the address ***imm16***.                   |          -          |         1          |         4         |
+| **b&ast;** ***imm9***  | **Relative branch**. Adds value ***imm9* &ast; *2*** to **PC**, thus passing control to the instruction located at the address **PC + (*imm9* &ast; *2*) + *2***. |          -          |         1          |         2         |
+|  **jsr** ***imm16***   |                **Jump to subroutine (Absolute)**. Pushes **PC** to stack and then does unconditional <br> absolute branch to address ***imm16***.                 |          -          |         2          |         4         |
+|   **jsr** ***imm9***   |                **Jump to subroutine (Relative)**. Pushes **PC** to stack and then does unconditional <br> relative branch with offset ***imm9***.                 |          -          |         2          |         2         |
+|   **jsrr** ***rd***    |           **Jump to subroutine by pointer**. Pushes **PC** to stack and then does unconditional <br> absolute branch to address contained in ***rd***.            |          -          |         2          |         2         |
+|   **int** ***imm9***   |                                         **Software interrupt**. Triggers an interrupt with vector with number ***imm9***.                                         |          -          |         4          |         2         |
+|        **rti**         |                **Return from interrupt**. Pops **PC** and **PS** from stack and thus returns <br> control to the caller code and restores **PS**.                 |          -          |         2          |         2         |
 
 **Macros**
 
@@ -250,19 +251,19 @@ bz  # branch if r0 == 0
 
 ### Logic instructions:
 
-|              Instruction               |                                                            Description                                                             |         Flags <br> affected          | Time <br> (cycles) | Size <br> (bytes) |
-|:--------------------------------------:|:----------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------:|:------------------:|:-----------------:|
-| **and** ***rs0***, ***rs1***, ***rd*** |                              Bitwise **and**. Computes ***rs0* & *rs1*** and puts result in ***rd***.                              |                 Z, N                 |         1          |         2         |
-| **or** ***rs0***, ***rs1***, ***rd***  |                                                 Bitwise **or**. Computes ***rs0* \                                                 | *rs1*** and puts result in ***rd***. |        Z, N        |         1         | 2 |
-| **xor** ***rs0***, ***rs1***, ***rd*** |                              Bitwise **xor**. Computes ***rs0* ^ *rs1*** and puts result in ***rd***.                              |                 Z, N                 |         1          |         2         |
-|       **not** ***rs***, ***rd***       |                         Bitwise **not**. Computes **~*rs*** (1's complement) and puts result in ***rd***.                          |                 Z, N                 |         1          |         2         |
-| **bic** ***rs0***, ***rs1***, ***rd*** | **Bit clear**. Clears bits in ***rs0*** that are set in ***rs1***. <br> Computes ***rs0* & (~*rs1***) and puts result in ***rd***. |                 Z, N                 |         1          |         2         |
+|              Instruction               |                                                            Description                                                             | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
+|:--------------------------------------:|:----------------------------------------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
+| **and** ***rs0***, ***rs1***, ***rd*** |                              Bitwise **and**. Computes ***rs0* & *rs1*** and puts result in ***rd***.                              |        Z, N         |         1          |         2         |
+| **or** ***rs0***, ***rs1***, ***rd***  |                            Bitwise **or**. Computes ***rs0* &vert; *rs1*** and puts result in ***rd***.                            |        Z, N         |         1          |         2         |
+| **xor** ***rs0***, ***rs1***, ***rd*** |                              Bitwise **xor**. Computes ***rs0* ^ *rs1*** and puts result in ***rd***.                              |        Z, N         |         1          |         2         |
+|       **not** ***rs***, ***rd***       |                         Bitwise **not**. Computes **~*rs*** (1's complement) and puts result in ***rd***.                          |        Z, N         |         1          |         2         |
+| **bic** ***rs0***, ***rs1***, ***rd*** | **Bit clear**. Clears bits in ***rs0*** that are set in ***rs1***. <br> Computes ***rs0* & (~*rs1***) and puts result in ***rd***. |        Z, N         |         1          |         2         |
 
 **Macros:**
 
-|                 Macro                  |                                    Description                                    |              Expansion               |
-|:--------------------------------------:|:---------------------------------------------------------------------------------:|:------------------------------------:|
-| **bis** ***rs0***, ***rs1***, ***rd*** | **Bit set**. Sets bits in ***rs0*** that are set in ***rs1***. Computes ***rs0* \ | *rs1*** and puts result in ***rd***. | **or** ***rs0***, ***rs1***, ***rd*** | 
+|                 Macro                  |                                                         Description                                                         |               Expansion               |
+|:--------------------------------------:|:---------------------------------------------------------------------------------------------------------------------------:|:-------------------------------------:|
+| **bis** ***rs0***, ***rs1***, ***rd*** | **Bit set**. Sets bits in ***rs0*** that are set in ***rs1***. Computes ***rs0* &vert; *rs1*** and puts result in ***rd***. | **or** ***rs0***, ***rs1***, ***rd*** | 
 
 ### Shift instructions:
 

--- a/docs/cdm16/cdm16-overview.md
+++ b/docs/cdm16/cdm16-overview.md
@@ -101,8 +101,7 @@ as `78 74` instead.*
 
 **Operations with stack:**
 
-+ When a **push** is performed, processor decrements **SP** by 2 bytes and stores data to memory pointed by new
-+ **SP** <br> *(resulting address is **SP-2**)*.
++ When a **push** is performed, processor decrements **SP** by 2 bytes and stores data to memory pointed by new **SP** <br> *(resulting address is **SP-2**)*.
 + When a **pop** is performed, processor loads data from memory pointed by **SP** and then increments **SP** by 2 bytes.
 
 |     Instruction     |                                     Description                                      | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |

--- a/docs/cdm16/cdm16-overview.md
+++ b/docs/cdm16/cdm16-overview.md
@@ -3,16 +3,21 @@
 **CdM-16** is 16-bit RISC processor.
 
 **Basic information:**
+
 + 64k address space
 + 16-bit arithmetics
 + 16-bit registers
 
 ## Registers
+
 + **8 general purpose** registers *(r0..r7)*
 + **r7** is called **fp** aka **frame pointer**, can be used with a special addressing mode
-+ **SP** - **stack pointer**, points to the top of the stack, stack grows downwards, should be aligned by 2, otherwise an exception is raised
-+ **PC** - **program coutner**, points to the next instruction that will be fetched, should be aligned by 2, otherwise an exception is raised
-+ **PSR** - **processor status register** *(or just **PS**)*, contains arithemic flag bit fields and interrupt enable bit field <br>
++ **SP** - **stack pointer**, points to the top of the stack, stack grows downwards, should be aligned by 2, otherwise
+  an exception is raised
++ **PC** - **program counter**, points to the next instruction that will be fetched, should be aligned by 2, otherwise
+  an exception is raised
++ **PSR** - **processor status register** *(or just **PS**)*, contains arithmetic flag bit fields and interrupt enable
+  bit field <br>
   *(sometimes called **PSW** - **processor status word**)*
 
 **Structure of *PS*:**
@@ -36,238 +41,259 @@
 
 ## Instruction operands
 
-**Operands used in the instructions can have following types:**
+**Operands used in the instructions can have the following types:**
+
 + **rs, rs0, rs1, rd** - registers *(r0, r1, r2, r3, r4, r5, r6, r7, fp)*
 
-+ **imm6, imm9** - short immediate value, can be interpreted as positive or negative (2's compement) integer
-  + **imm6** - can take values from -64 to 63
-  + **imm9** - can take values from -512 to 511
++ **imm6, imm9** - short immediate value, can be interpreted as positive or negative (2's complement) integer
+    + **imm6** - can take values from -64 to 63
+    + **imm9** - can take values from -512 to 511
 
 + **imm16** - long immediate value, 16-bit integer or label
 
-Some commands have variants with both **imm6/imm9** and **imm16** operands, but programmer don't have to worry about it as assembler will put appropriate command automatically.
+Some commands have variants with both **imm6/imm9** and **imm16** operands, but programmer don't have to worry about it
+as assembler will put appropriate command automatically.
 However, programmer should not exceed size of maximum available operand type.
 
-> This is done that way as, in fact, it gives some ability to optimize code as **imm6/imm9** variants take less space (2 bytes) than **imm16** variants (4 bytes).
-> 
-> *Example: `ldi r0, 15` with long immediate is encoded as `10 20 0f 00`, but assembler will optimize it and encode it as `78 74` instead.*
+> This is done that way as, in fact, it gives some ability to optimize code as **imm6/imm9** variants take less space (2
+> bytes) than **imm16** variants (4 bytes).
+>
+> *Example: `ldi r0, 15` with long immediate is encoded as `10 20 0f 00`, but assembler will optimize it and encode it
+as `78 74` instead.*
 
-## Instuction set
+## Instruction set
 
 ### Memory access instructions
 
 **Store and load by address:**
-|              Instruction               |                     Description                       | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: | :----------------: | :---------------: |
-| **ldw** ***rs***, ***rd*** | **Load word**. Loads 2 bytes from data memory pointed by ***rs*** to ***rd***. | - | 1-2 | 2 |
-| **ldb** ***rs***, ***rd*** | **Load byte**. Loads a byte from data memory pointed by ***rs*** to ***rd***. | - | 1-2 | 2 |
-| **ldsb** ***rs***, ***rd*** | **Load signed byte**. Loads a byte from data memory pointed <br> by ***rs*** to ***rd*** with sign-extend. | - | 1-2 | 2 |
-| **lcw** ***rs***, ***rd*** | **Load constant word**. Loads 2 bytes from instruction memory pointed <br> by ***rs*** to ***rd***. | - | 1-2 | 2 |
-| **lcb** ***rs***, ***rd*** | **Load constant byte**. Loads a byte from instruction memory pointed <br> by ***rs*** to ***rd***. | - | 1-2 | 2 |
-| **lcsb** ***rs***, ***rd*** | **Load constant signed byte**. Loads a byte from  instruction memory pointed <br> by ***rs*** to ***rd*** with sign-extend. | - | 1-2 | 2 |
-| **stw** ***rs***, ***rd*** | **Store word**. Stores 2 bytes from ***rd*** to data memory pointed by ***rs***. | - | 1-2 | 2 |
-| **stb** ***rs***, ***rd*** | **Store byte**. Stores a lower byte from ***rd*** to data memory pointed by ***rs***. | - | 1-2 | 2 |
+
+|         Instruction         |                                                         Description                                                         | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
+|:---------------------------:|:---------------------------------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
+| **ldw** ***rs***, ***rd***  |                       **Load word**. Loads 2 bytes from data memory pointed by ***rs*** to ***rd***.                        |          -          |        1-2         |         2         |
+| **ldb** ***rs***, ***rd***  |                        **Load byte**. Loads a byte from data memory pointed by ***rs*** to ***rd***.                        |          -          |        1-2         |         2         |
+| **ldsb** ***rs***, ***rd*** |         **Load signed byte**. Loads a byte from data memory pointed <br> by ***rs*** to ***rd*** with sign-extend.          |          -          |        1-2         |         2         |
+| **lcw** ***rs***, ***rd***  |             **Load constant word**. Loads 2 bytes from instruction memory pointed <br> by ***rs*** to ***rd***.             |          -          |        1-2         |         2         |
+| **lcb** ***rs***, ***rd***  |             **Load constant byte**. Loads a byte from instruction memory pointed <br> by ***rs*** to ***rd***.              |          -          |        1-2         |         2         |
+| **lcsb** ***rs***, ***rd*** | **Load constant signed byte**. Loads a byte from  instruction memory pointed <br> by ***rs*** to ***rd*** with sign-extend. |          -          |        1-2         |         2         |
+| **stw** ***rs***, ***rd***  |                      **Store word**. Stores 2 bytes from ***rd*** to data memory pointed by ***rs***.                       |          -          |        1-2         |         2         |
+| **stb** ***rs***, ***rd***  |                    **Store byte**. Stores a lower byte from ***rd*** to data memory pointed by ***rs***.                    |          -          |        1-2         |         2         |
 
 **These instructions have 3 operand analogues:**
-|              Instruction               |                     Description                       | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: | :----------------: | :---------------: |
-| **ldw** ***rs0***, ***rs1***, ***rd*** | **Load word**. Loads 2 bytes from data memory pointed by ***rs0* + *rs1*** to ***rd***. | - | 1-2 | 2 |
-| **ldb** ***rs0***, ***rs1***, ***rd*** | **Load byte**. Loads a byte from data memory pointed by ***rs0* + *rs1*** to ***rd***. | - | 1-2 | 2 |
-| **ldsb** ***rs0***, ***rs1***, ***rd*** | **Load signed byte**. Loads a byte from data memory pointed <br> by ***rs0* + *rs1*** to ***rd*** with sign-extend. | - | 1-2 | 2 |
-| **lcw** ***rs0***, ***rs1***, ***rd*** | **Load constant word**. Loads 2 bytes from instruction memory pointed <br> by ***rs0* + *rs1*** to ***rd***. | - | 1-2 | 2 |
-| **lcb** ***rs0***, ***rs1***, ***rd*** | **Load constant byte**. Loads a byte from instruction memory pointed <br> by ***rs0* + *rs1*** to ***rd***. | - | 1-2 | 2 |
-| **lcsb** ***rs0***, ***rs1***, ***rd*** | **Load constant signed byte**. Loads a byte from  instruction memory pointed <br> by ***rs0* + *rs1*** to ***rd*** with sign-extend. | - | 1-2 | 2 |
-| **stw** ***rs0***, ***rs1***, ***rd*** | **Store word**. Stores 2 bytes from ***rd*** to data memory pointed by ***rs0* + *rs1***. | - | 1-2 | 2 |
-| **stb** ***rs0***, ***rs1***, ***rd*** | **Store byte**. Stores a lower byte from ***rd*** to data memory pointed by ***rs0* + *rs1***. | - | 1-2 | 2 |
+
+|               Instruction               |                                                             Description                                                              | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
+|:---------------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
+| **ldw** ***rs0***, ***rs1***, ***rd***  |                       **Load word**. Loads 2 bytes from data memory pointed by ***rs0* + *rs1*** to ***rd***.                        |          -          |        1-2         |         2         |
+| **ldb** ***rs0***, ***rs1***, ***rd***  |                        **Load byte**. Loads a byte from data memory pointed by ***rs0* + *rs1*** to ***rd***.                        |          -          |        1-2         |         2         |
+| **ldsb** ***rs0***, ***rs1***, ***rd*** |         **Load signed byte**. Loads a byte from data memory pointed <br> by ***rs0* + *rs1*** to ***rd*** with sign-extend.          |          -          |        1-2         |         2         |
+| **lcw** ***rs0***, ***rs1***, ***rd***  |             **Load constant word**. Loads 2 bytes from instruction memory pointed <br> by ***rs0* + *rs1*** to ***rd***.             |          -          |        1-2         |         2         |
+| **lcb** ***rs0***, ***rs1***, ***rd***  |             **Load constant byte**. Loads a byte from instruction memory pointed <br> by ***rs0* + *rs1*** to ***rd***.              |          -          |        1-2         |         2         |
+| **lcsb** ***rs0***, ***rs1***, ***rd*** | **Load constant signed byte**. Loads a byte from  instruction memory pointed <br> by ***rs0* + *rs1*** to ***rd*** with sign-extend. |          -          |        1-2         |         2         |
+| **stw** ***rs0***, ***rs1***, ***rd***  |                      **Store word**. Stores 2 bytes from ***rd*** to data memory pointed by ***rs0* + *rs1***.                       |          -          |        1-2         |         2         |
+| **stb** ***rs0***, ***rs1***, ***rd***  |                    **Store byte**. Stores a lower byte from ***rd*** to data memory pointed by ***rs0* + *rs1***.                    |          -          |        1-2         |         2         |
 
 **Macros:**
-|                  Macro                 |                     Description                       |      Expansion      |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: |
-| **ld** ***rs***, ***rd*** | **Load from memory**. Simulates **CdM-8/8e** **ld** instruction. Operates with words. | **ldw** ***rs***, ***rd*** | 
-| **ldc** ***rs***, ***rd*** | **Load constatnt from memory**. Simulates **CdM-8/8e** **ldc** instruction. Operates with words. | **lcw** ***rs***, ***rd*** | 
-| **st** ***rs***, ***rd*** | **Store to memory**. Simulates **CdM-8/8e** **st** instruction. Operates with words. | **stw** ***rs***, ***rd*** | 
+
+|           Macro            |                                           Description                                           |         Expansion          |
+|:--------------------------:|:-----------------------------------------------------------------------------------------------:|:--------------------------:|
+| **ld** ***rs***, ***rd***  |      **Load from memory**. Simulates **CdM-8/8e** **ld** instruction. Operates with words.      | **ldw** ***rs***, ***rd*** | 
+| **ldc** ***rs***, ***rd*** | **Load constant from memory**. Simulates **CdM-8/8e** **ldc** instruction. Operates with words. | **lcw** ***rs***, ***rd*** | 
+| **st** ***rs***, ***rd***  |      **Store to memory**. Simulates **CdM-8/8e** **st** instruction. Operates with words.       | **stw** ***rs***, ***rd*** | 
 
 **Operations with stack:**
 
-+ When a **push** is performed, processor decrements **SP** by 2 bytes and stores data to memory pointed by new **SP** <br> *(resulting address is **SP-2**)*.
++ When a **push** is performed, processor decrements **SP** by 2 bytes and stores data to memory pointed by new **SP
+  ** <br> *(resulting address is **SP-2**)*.
 + When a **pop** is performed, processor loads data from memory pointed by **SP** and then increments **SP** by 2 bytes.
 
-|              Instruction               |                     Description                       | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: | :----------------: | :---------------: |
-| **push** ***rd*** | **Push register**. Stores contents of ***rd*** to the top of the stack. | - | 1 | 2 |
-| **push** ***imm9*** | **Push immediate**. Stores immediate value ***imm9*** to the top of the stack. | - | 1 | 2 |
-| **pop** ***rd*** | **Pop register**. Loads a value from the top of the stack to ***rd***. | - | 1 | 2 |
-| **pupc** | **Push PC**. Pushes ***PC*** to the stack. | - | 1 | 2 |
-| **popc** | **Pop PC**. Pops ***PC*** from the stack. | - | 1 | 2 |
-| **pusp** | **Push SP**. Pushes ***SP*** to the stack. | - | 1 | 2 |
-| **posp** | **Pop SP**. Pops ***SP*** from the stack. This operation doesn't increment ***SP***. | - | 1 | 2 |
-| **pups** | **Push PS**. Pushes ***PS*** to the stack. | - | 1 | 2 |
-| **pops** | **Pop PS**. Pops ***PS*** from the stack. | - | 1 | 2 |
+|     Instruction     |                                     Description                                      | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
+|:-------------------:|:------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
+|  **push** ***rd***  |       **Push register**. Stores contents of ***rd*** to the top of the stack.        |          -          |         1          |         2         |
+| **push** ***imm9*** |    **Push immediate**. Stores immediate value ***imm9*** to the top of the stack.    |          -          |         1          |         2         |
+|  **pop** ***rd***   |        **Pop register**. Loads a value from the top of the stack to ***rd***.        |          -          |         1          |         2         |
+|      **pupc**       |                      **Push PC**. Pushes ***PC*** to the stack.                      |          -          |         1          |         2         |
+|      **popc**       |                      **Pop PC**. Pops ***PC*** from the stack.                       |          -          |         1          |         2         |
+|      **pusp**       |                      **Push SP**. Pushes ***SP*** to the stack.                      |          -          |         1          |         2         |
+|      **posp**       | **Pop SP**. Pops ***SP*** from the stack. This operation doesn't increment ***SP***. |          -          |         1          |         2         |
+|      **pups**       |                      **Push PS**. Pushes ***PS*** to the stack.                      |          -          |         1          |         2         |
+|      **pops**       |                      **Pop PS**. Pops ***PS*** from the stack.                       |          -          |         1          |         2         |
 
 **Operations with frame pointer:**
 
-Processor can access data by adding a constant to **fp**. There, ***off*** is an immediate value, offset to **fp** in bytes.
+Processor can access data by adding a constant to **fp**. There, ***off*** is an immediate value, offset to **fp** in
+bytes.
 
 There are some limitations:
+
 + For **byte** variants: $-64 \leq off < 64$
 + For **word** variants: $-128 \leq off < 128$ and ***off*** must be **even**
 
-> **Note:** ***off*** will be expanded by assembler as ***off*** = ***imm6* \* *size***. This gives limitations above. 
+> **Note:** ***off*** will be expanded by assembler as ***off*** = ***imm6* \* *size***. This gives limitations above.
 
-|              Instruction               |                     Description                       | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: | :----------------: | :---------------: |
-| **lsw** ***rd***, ***off*** | **Load word relative to *fp***. Loads a word from memory locaton ***fp* + *off*** to ***rd***. | - | 1 | 2 |
-| **lsb** ***rd***, ***off*** | **Load byte relative to *fp***. Loads a byte from memory locaton ***fp* + *off*** to ***rd***. | - | 1 | 2 |
-| **lssb** ***rd***, ***off*** | **Load signed byte relative to *fp***. Loads a byte from memory<br>locaton ***fp* + *off*** to ***rd*** with sign-extend. | - | 1 | 2 |
-| **ssw** ***rd***, ***off*** | **Store word relative to *fp***. Stores a word from ***rd*** to memory locaton ***fp* + *off***. | - | 1 | 2 |
-| **ssb** ***rd***, ***off*** | **Store byte relative to *fp***. Stores a lower byte of ***rd*** to memory locaton ***fp* + *off***. | - | 1 | 2 |
+|         Instruction          |                                                        Description                                                         | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
+|:----------------------------:|:--------------------------------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
+| **lsw** ***rd***, ***off***  |              **Load word relative to *fp***. Loads a word from memory location ***fp* + *off*** to ***rd***.               |          -          |         1          |         2         |
+| **lsb** ***rd***, ***off***  |              **Load byte relative to *fp***. Loads a byte from memory location ***fp* + *off*** to ***rd***.               |          -          |         1          |         2         |
+| **lssb** ***rd***, ***off*** | **Load signed byte relative to *fp***. Loads a byte from memory<br>location ***fp* + *off*** to ***rd*** with sign-extend. |          -          |         1          |         2         |
+| **ssw** ***rd***, ***off***  |             **Store word relative to *fp***. Stores a word from ***rd*** to memory location ***fp* + *off***.              |          -          |         1          |         2         |
+| **ssb** ***rd***, ***off***  |           **Store byte relative to *fp***. Stores a lower byte of ***rd*** to memory location ***fp* + *off***.            |          -          |         1          |         2         |
 
 ### Flow control instructions:
-Asterisk *(\*)* in branch instuctions is a condition. It must be replaced with one of condition codes:
 
-| Condition code | Description | 
-| :------------: | :---------: |
-| **eq/z** | equal, equal to zero, **Z** is set |
-| **ne/nz** | not equal, not zero, **Z** is clear |
-| **hs/cs** | unsigned higher or same, **C** is set |
-| **lo/cc** | unsigned lower, **C** is clear |
-| **mi** | negative (minus) |
-| **pl** | positive or zero (plus) |
-| **vs** | **V** is set |
-| **vc** | **V** is clear |
-| **hi** | unsigned higher |
-| **ls** | unsigned lower or same |
-| **ge** | greater than or equal |
-| **lt** | less than, less than zero |
-| **gt** | greater than |
-| **le** | less than or equal |
-| **r** | unconditional branch |
+Asterisk *(\*)* in branch instructions is a condition. It must be replaced with one of condition codes:
 
-Instruction changes **PC** only if this condition is met, processor determines it by testing condition against **C, V, Z, N** flags in **PS** register.
+| Condition code |              Description              | 
+|:--------------:|:-------------------------------------:|
+|    **eq/z**    |  equal, equal to zero, **Z** is set   |
+|   **ne/nz**    |  not equal, not zero, **Z** is clear  |
+|   **hs/cs**    | unsigned higher or same, **C** is set |
+|   **lo/cc**    |    unsigned lower, **C** is clear     |
+|     **mi**     |           negative (minus)            |
+|     **pl**     |        positive or zero (plus)        |
+|     **vs**     |             **V** is set              |
+|     **vc**     |            **V** is clear             |
+|     **hi**     |            unsigned higher            |
+|     **ls**     |        unsigned lower or same         |
+|     **ge**     |         greater than or equal         |
+|     **lt**     |       less than, less than zero       |
+|     **gt**     |             greater than              |
+|     **le**     |          less than or equal           |
+|     **r**      |         unconditional branch          |
+
+Instruction changes **PC** only if this condition is met, processor determines it by testing condition against **C, V,
+Z, N** flags in **PS** register.
 
 *Examples:*
+
 ```python
-br foo # unconditional branch
-  
-cmp r0, r1 
-beq bar # branch if r0 == r1
-  
-tst r0
-bz # branch if r0 == 0
+br
+foo  # unconditional branch
+
+cmp
+r0, r1
+beq
+bar  # branch if r0 == r1
+
+tst
+r0
+bz  # branch if r0 == 0
 ```
 
-|              Instruction               |                     Description                       | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: | :----------------: | :---------------: |
-| **b\*** ***imm16*** | **Absolute branch**. Loads ***imm16*** to **PC**, thus passing control to the instruction located at the address ***imm16***. | - | 1 | 4 |
-| **b\*** ***imm9*** | **Relative branch**. Adds value ***imm9* \* *2*** to **PC**, thus passing control to the instruction located at the address **PC + (*imm9* \* *2*) + *2***. | - | 1 | 2 |
-| **jsr** ***imm16*** | **Jump to subroutine (Absolute)**. Pushes **PC** to stack and then does unconditional <br> absolute branch to address ***imm16***. | - | 2 | 4 |
-| **jsr** ***imm9*** | **Jump to subroutine (Relative)**. Pushes **PC** to stack and then does unconditional <br> relative branch with offset ***imm9***. | - | 2 | 2 |
-| **jsrr** ***rd*** | **Jump to subroutine by pointer**. Pushes **PC** to stack and then does unconditional <br> absolute branch to address contained in ***rd***. | - | 2 | 2 |
-| **int** ***imm9*** | **Sofware interrupt**. Triggers an interrupt with vector with number ***imm9***. | - | 4 | 2 |
-| **rti** | **Return from iterrupt**. Pops **PC** and **PS** from stack and thus returns <br> control to the caller code and restores **PS**. | - | 2 | 2 |
+|     Instruction     |                                                                         Description                                                                         | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
+|:-------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
+| **b\*** ***imm16*** |                **Absolute branch**. Loads ***imm16*** to **PC**, thus passing control to the instruction located at the address ***imm16***.                |          -          |         1          |         4         |
+| **b\*** ***imm9***  | **Relative branch**. Adds value ***imm9* \* *2*** to **PC**, thus passing control to the instruction located at the address **PC + (*imm9* \* *2*) + *2***. |          -          |         1          |         2         |
+| **jsr** ***imm16*** |             **Jump to subroutine (Absolute)**. Pushes **PC** to stack and then does unconditional <br> absolute branch to address ***imm16***.              |          -          |         2          |         4         |
+| **jsr** ***imm9***  |             **Jump to subroutine (Relative)**. Pushes **PC** to stack and then does unconditional <br> relative branch with offset ***imm9***.              |          -          |         2          |         2         |
+|  **jsrr** ***rd***  |        **Jump to subroutine by pointer**. Pushes **PC** to stack and then does unconditional <br> absolute branch to address contained in ***rd***.         |          -          |         2          |         2         |
+| **int** ***imm9***  |                                      **Software interrupt**. Triggers an interrupt with vector with number ***imm9***.                                      |          -          |         4          |         2         |
+|       **rti**       |             **Return from interrupt**. Pops **PC** and **PS** from stack and thus returns <br> control to the caller code and restores **PS**.              |          -          |         2          |         2         |
 
 **Macros**
-|                  Macro                 |                     Description                       |      Expansion      |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: |
-| **rts** | **Return from subroutine**. Pops **PC** from stack and thus returns control to the caller code. <br> *(Assuming return address was previosly pushed to stack, for exmaple, with **jsr**)* | **popc** |
 
+|  Macro  |                                                                                        Description                                                                                         | Expansion |
+|:-------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:---------:|
+| **rts** | **Return from subroutine**. Pops **PC** from stack and thus returns control to the caller code. <br> *(Assuming return address was previously pushed to stack, for example, with **jsr**)* | **popc**  |
 
 ### Register transfer instructions:
-|              Instruction               |                     Description                       | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: | :----------------: | :---------------: |
-| **ldi** ***rd***, ***imm16*** | **Load immediate to register**. Loads immedaite value ***imm16*** to ***rd***. | - | 1 | 4 |
-| **ldi** ***rd***, ***imm6*** | **Load short immediate to register**. Loads immedaite value ***imm6*** to ***rd***. | - | 1 | 2 |
-| **move** ***rs***, ***rd*** | **Copy register**. Copies value from ***rs*** to ***rd***. | C, V, Z, N | 1 | 2 |
-| **addsp** ***imm9*** | **Add immediate to SP**. Adds ***imm9* * *2*** to **SP**. <br> (***imm9** is number of **words***) | - | 1 | 2 |
-| **ldsp** ***rd*** | **Load SP**. Copies value from **SP** to ***rd***. | - | 1 | 2 |
-| **stsp** ***rd*** | **Store SP**. Copies value from ***rd*** to **SP**. | - | 1 | 2 |
-| **ldps** ***rd*** | **Load PS**. Copies value from **PS** to ***rd***. | - | 1 | 2 |
-| **stps** ***rd*** | **Store PS**. Copies value from ***rd*** to **PS**. | - | 1 | 2 |
-| **ldpc** ***rd*** | **Load PC**. Copies value from **PC** to ***rd***. | - | 1 | 2 |
-| **stpc** ***rd*** | **Store PC**. Copies value from ***rd*** to **PC**. | - | 1 | 2 |
+
+|          Instruction          |                                            Description                                             | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
+|:-----------------------------:|:--------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
+| **ldi** ***rd***, ***imm16*** |           **Load immediate to register**. Loads immediate value ***imm16*** to ***rd***.           |          -          |         1          |         4         |
+| **ldi** ***rd***, ***imm6***  |        **Load short immediate to register**. Loads immediate value ***imm6*** to ***rd***.         |          -          |         1          |         2         |
+|  **move** ***rs***, ***rd***  |                     **Copy register**. Copies value from ***rs*** to ***rd***.                     |     C, V, Z, N      |         1          |         2         |
+|     **addsp** ***imm9***      | **Add immediate to SP**. Adds ***imm9* * *2*** to **SP**. <br> (***imm9** is number of **words***) |          -          |         1          |         2         |
+|       **ldsp** ***rd***       |                         **Load SP**. Copies value from **SP** to ***rd***.                         |          -          |         1          |         2         |
+|       **stsp** ***rd***       |                        **Store SP**. Copies value from ***rd*** to **SP**.                         |          -          |         1          |         2         |
+|       **ldps** ***rd***       |                         **Load PS**. Copies value from **PS** to ***rd***.                         |          -          |         1          |         2         |
+|       **stps** ***rd***       |                        **Store PS**. Copies value from ***rd*** to **PS**.                         |          -          |         1          |         2         |
+|       **ldpc** ***rd***       |                         **Load PC**. Copies value from **PC** to ***rd***.                         |          -          |         1          |         2         |
+|       **stpc** ***rd***       |                        **Store PC**. Copies value from ***rd*** to **PC**.                         |          -          |         1          |         2         |
 
 ### Processor control instructions:
-|              Instruction               |                     Description                       | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: | :----------------: | :---------------: |
-| **halt** | **Halt processor**. Stops processor clock, changes processor status to **HALTED**. | - | 1 | 2 |
-| **wait** | **Wait for an interrupt**. Stops processor clock until an interrupt or an exception <br> occurs, changes processor status to **WAITING**. | - | 1 | 2 |
-| **reset** | **Reset processor**. Fetches reset vector thus performing soft reset. | - | 2 | 2 |
-| **reset** ***imm9*** | **Reset processor**. Fetches vector ***imm9*** thus performing soft reset. | - | 2 | 2 |
-| **ei** | **Enable interrupts**. Sets **I** bit *(bit 15)* in **PS** thus enabling interrupts. | - | 1 | 2 |
-| **di** | **Disable interrupts**. Clears **I** bit *(bit 15)* in **PS** thus disabling interrupts. | - | 1 | 2 |
+
+|     Instruction      |                                                                Description                                                                | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
+|:--------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
+|       **halt**       |                            **Halt processor**. Stops processor clock, changes processor status to **HALTED**.                             |          -          |         1          |         2         |
+|       **wait**       | **Wait for an interrupt**. Stops processor clock until an interrupt or an exception <br> occurs, changes processor status to **WAITING**. |          -          |         1          |         2         |
+|      **reset**       |                                   **Reset processor**. Fetches reset vector thus performing soft reset.                                   |          -          |         2          |         2         |
+| **reset** ***imm9*** |                                **Reset processor**. Fetches vector ***imm9*** thus performing soft reset.                                 |          -          |         2          |         2         |
+|        **ei**        |                           **Enable interrupts**. Sets **I** bit *(bit 15)* in **PS** thus enabling interrupts.                            |          -          |         1          |         2         |
+|        **di**        |                         **Disable interrupts**. Clears **I** bit *(bit 15)* in **PS** thus disabling interrupts.                          |          -          |         1          |         2         |
 
 **Macros:**
-|                  Macro                 |                     Description                       |      Expansion      |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: |
-| **nop** | **No operation**. Performs no operation. Processor executes this instruction with no side <br> effects except for updated **PC**. Can be used for creating delay or filling up space.  | **bfalse** ***_nop*** |
+
+|  Macro  |                                                                                      Description                                                                                      |       Expansion       |
+|:-------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:---------------------:|
+| **nop** | **No operation**. Performs no operation. Processor executes this instruction with no side <br> effects except for updated **PC**. Can be used for creating delay or filling up space. | **bfalse** ***_nop*** |
 
 ### Arithmetic instructions:
-|              Instruction               |                     Description                       | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: | :----------------: | :---------------: |
-| **add** ***rs0***, ***rs1***, ***rd*** | **Add**. Computes ***rs0* + *rs1*** and puts result in ***rd***. | C, V, Z, N | 1 | 2 |
-| **add** ***rd***, ***imm6*** | **Add immediate**. Computes ***rs0* + *imm6*** and puts result in ***rd***. | C, V, Z, N | 1 | 2 |
-| **addc** ***rs0***, ***rs1***, ***rd*** | **Add with carry**. Computes ***rs0* + *rs1* + *C*** and puts result in ***rd***. | C, V, Z, N | 1 | 2 |
-| **sub** ***rs0***, ***rs1***, ***rd*** | **Substract**. Computes ***rs0* - *rs1*** and puts result in ***rd***. | C, V, Z, N | 1 | 2 |
-| **sub** ***rd***, ***imm6*** | **Substract immediate**. Computes ***rs0* - *imm6*** and puts result in ***rd***. | C, V, Z, N | 1 | 2 |
-| **subc** ***rs0***, ***rs1***, ***rd*** | **Substract with carry**. Computes ***rs0* - *rs1* + *C* - *1*** and puts result in ***rd***. | C, V, Z, N | 1 | 2 |
-| **neg** ***rs***, ***rd*** | **Negation**. Computes **-*rs*** (2's complement) and puts result in ***rd***. | Z, N | 1 | 2 |
-| **sxt** ***rs***, ***rd*** | **Sign extend**. Fills higher 8 bits with 7-th bit of ***rs*** and puts result in ***rd***. | Z, N | 1 | 2 |
-| **scl** ***rs***, ***rd*** | **Sign clear**. Clears higher 8 bits of ***rs*** and puts result in ***rd***. | Z, N | 1 | 2 |
+
+|               Instruction               |                                         Description                                          | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
+|:---------------------------------------:|:--------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
+| **add** ***rs0***, ***rs1***, ***rd***  |               **Add**. Computes ***rs0* + *rs1*** and puts result in ***rd***.               |     C, V, Z, N      |         1          |         2         |
+|      **add** ***rd***, ***imm6***       |         **Add immediate**. Computes ***rs0* + *imm6*** and puts result in ***rd***.          |     C, V, Z, N      |         1          |         2         |
+| **addc** ***rs0***, ***rs1***, ***rd*** |      **Add with carry**. Computes ***rs0* + *rs1* + *C*** and puts result in ***rd***.       |     C, V, Z, N      |         1          |         2         |
+| **sub** ***rs0***, ***rs1***, ***rd***  |            **Subtract**. Computes ***rs0* - *rs1*** and puts result in ***rd***.             |     C, V, Z, N      |         1          |         2         |
+|      **sub** ***rd***, ***imm6***       |       **Subtract immediate**. Computes ***rs0* - *imm6*** and puts result in ***rd***.       |     C, V, Z, N      |         1          |         2         |
+| **subc** ***rs0***, ***rs1***, ***rd*** | **Subtract with carry**. Computes ***rs0* - *rs1* + *C* - *1*** and puts result in ***rd***. |     C, V, Z, N      |         1          |         2         |
+|       **neg** ***rs***, ***rd***        |        **Negation**. Computes **-*rs*** (2's complement) and puts result in ***rd***.        |        Z, N         |         1          |         2         |
+|       **sxt** ***rs***, ***rd***        | **Sign extend**. Fills higher 8 bits with 7-th bit of ***rs*** and puts result in ***rd***.  |        Z, N         |         1          |         2         |
+|       **scl** ***rs***, ***rd***        |        **Sign clear**. Clears higher 8 bits of ***rs*** and puts result in ***rd***.         |        Z, N         |         1          |         2         |
 
 **Macros:**
-|                  Macro                 |                     Description                       |      Expansion      |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: |
-| **inc** ***rd*** | **Increment register**. Increments register by 1 and sets all flags according to the result. | **add** ***rd***, ***1*** | 
-| **dec** ***rd*** | **Decrement register**. Decrements register by 1 and sets all flags according to the result. | **sub** ***rd***, ***1*** |
+
+|      Macro       |                                          Description                                           |         Expansion          |
+|:----------------:|:----------------------------------------------------------------------------------------------:|:--------------------------:|
+| **inc** ***rd*** |  **Increment register**. Increments register by 1 and sets all flags according to the result.  | **add** ***rd***, ***1***  | 
+| **dec** ***rd*** |  **Decrement register**. Decrements register by 1 and sets all flags according to the result.  | **sub** ***rd***, ***1***  |
 | **clr** ***rd*** | **Clear register**. Sets register to 0 and sets flags according to its value before operation. | **sub** ***rd***, ***rd*** | 
 
 ### Logic instructions:
-|              Instruction               |                     Description                       | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: | :----------------: | :---------------: |
-| **and** ***rs0***, ***rs1***, ***rd*** | Bitwise **and**. Computes ***rs0* & *rs1*** and puts result in ***rd***. | Z, N | 1 | 2 |
-| **or** ***rs0***, ***rs1***, ***rd*** | Bitwise **or**. Computes ***rs0* \| *rs1*** and puts result in ***rd***. | Z, N | 1 | 2 |
-| **xor** ***rs0***, ***rs1***, ***rd*** | Bitwise **xor**. Computes ***rs0* ^ *rs1*** and puts result in ***rd***. | Z, N | 1 | 2 |
-| **not** ***rs***, ***rd*** | Bitwise **not**. Computes **~*rs*** (1's complement) and puts result in ***rd***. | Z, N | 1 | 2 |
-| **bic** ***rs0***, ***rs1***, ***rd*** | **Bit clear**. Clears bits in ***rs0*** that are set in ***rs1***. <br> Computes ***rs0* & (~*rs1***) and puts result in ***rd***. | Z, N | 1 | 2 |
+
+|              Instruction               |                                                            Description                                                             |         Flags <br> affected          | Time <br> (cycles) | Size <br> (bytes) |
+|:--------------------------------------:|:----------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------:|:------------------:|:-----------------:|
+| **and** ***rs0***, ***rs1***, ***rd*** |                              Bitwise **and**. Computes ***rs0* & *rs1*** and puts result in ***rd***.                              |                 Z, N                 |         1          |         2         |
+| **or** ***rs0***, ***rs1***, ***rd***  |                                                 Bitwise **or**. Computes ***rs0* \                                                 | *rs1*** and puts result in ***rd***. |        Z, N        |         1         | 2 |
+| **xor** ***rs0***, ***rs1***, ***rd*** |                              Bitwise **xor**. Computes ***rs0* ^ *rs1*** and puts result in ***rd***.                              |                 Z, N                 |         1          |         2         |
+|       **not** ***rs***, ***rd***       |                         Bitwise **not**. Computes **~*rs*** (1's complement) and puts result in ***rd***.                          |                 Z, N                 |         1          |         2         |
+| **bic** ***rs0***, ***rs1***, ***rd*** | **Bit clear**. Clears bits in ***rs0*** that are set in ***rs1***. <br> Computes ***rs0* & (~*rs1***) and puts result in ***rd***. |                 Z, N                 |         1          |         2         |
 
 **Macros:**
-|                  Macro                 |                     Description                       |      Expansion      |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: |
-| **bis** ***rs0***, ***rs1***, ***rd*** | **Bit set**. Sets bits in ***rs0*** that are set in ***rs1***. Computes ***rs0* \| *rs1*** and puts result in ***rd***. | **or** ***rs0***, ***rs1***, ***rd*** | 
+
+|                 Macro                  |                                    Description                                    |              Expansion               |
+|:--------------------------------------:|:---------------------------------------------------------------------------------:|:------------------------------------:|
+| **bis** ***rs0***, ***rs1***, ***rd*** | **Bit set**. Sets bits in ***rs0*** that are set in ***rs1***. Computes ***rs0* \ | *rs1*** and puts result in ***rd***. | **or** ***rs0***, ***rs1***, ***rd*** | 
 
 ### Shift instructions:
-**CdM-16** has a barrel shifter that can perform shifts from **1** to **8** postitions, ***val*** is an immediate value that determines distance of shift. It can take values from **1** to **8**, ***val* == 0** is considered invalid.
 
-> **Note:** ***val*** will be expanded by assembler as ***val*** = ***imm3* + 1**. This gives limitations above. 
+**CdM-16** has a barrel shifter that can perform shifts from **1** to **8** positions, ***val*** is an immediate value
+that determines distance of shift. It can take values from **1** to **8**, ***val* == 0** is considered invalid.
 
-+ **Z, N** flags is set accoding to resulting number
+> **Note:** ***val*** will be expanded by assembler as ***val*** = ***imm3* + 1**. This gives limitations above.
+
++ **Z, N** flags is set according to resulting number
 + **C** is set according to last shifted bit
 
-|              Instruction               |                     Description                       | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: | :----------------: | :---------------: |
-| **shl** ***rs***, ***rd***, ***val*** | **Logic left shift**. Shifts left and fills with zeros. | C, Z, N | 1 | 2 |
-| **shr** ***rs***, ***rd***, ***val*** | **Logic right shift**. Shifts right and fills with zeros. | C, Z, N | 1 | 2 |
-| **shra** ***rs***, ***rd***, ***val*** | **Arithmetic right shift**. Shifts right and fills with sign bit <br> *(most significant bit of inital number)*. | C, Z, N | 1 | 2 |
-| **rol** ***rs***, ***rd***, ***val*** | **Cyclic left shift**. Shifts left, bit 15 shifts to bit 0. | C, Z, N | 1 | 2 |
-| **ror** ***rs***, ***rd***, ***val*** | **Cyclic right shift**. Shifts right, bit 0 shifts to bit 15. | C, Z, N | 1 | 2 |
-| **rcl** ***rs***, ***rd***, ***val*** | **Cyclic left shift with carry**. Shifts left, bit 15 shifts to **C**, old **C** shifts to bit 0. | C, Z, N | 1 | 2 |
-| **rcr** ***rs***, ***rd***, ***val*** | **Cyclic right shift with carry**. Shifts right, bit 0 shifts to **C**, old **C** shifts to bit 15. | C, Z, N | 1 | 2 |
+|              Instruction               |                                                    Description                                                    | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
+|:--------------------------------------:|:-----------------------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
+| **shl** ***rs***, ***rd***, ***val***  |                              **Logic left shift**. Shifts left and fills with zeros.                              |       C, Z, N       |         1          |         2         |
+| **shr** ***rs***, ***rd***, ***val***  |                             **Logic right shift**. Shifts right and fills with zeros.                             |       C, Z, N       |         1          |         2         |
+| **shra** ***rs***, ***rd***, ***val*** | **Arithmetic right shift**. Shifts right and fills with sign bit <br> *(most significant bit of initial number)*. |       C, Z, N       |         1          |         2         |
+| **rol** ***rs***, ***rd***, ***val***  |                            **Cyclic left shift**. Shifts left, bit 15 shifts to bit 0.                            |       C, Z, N       |         1          |         2         |
+| **ror** ***rs***, ***rd***, ***val***  |                           **Cyclic right shift**. Shifts right, bit 0 shifts to bit 15.                           |       C, Z, N       |         1          |         2         |
+| **rcl** ***rs***, ***rd***, ***val***  |         **Cyclic left shift with carry**. Shifts left, bit 15 shifts to **C**, old **C** shifts to bit 0.         |       C, Z, N       |         1          |         2         |
+| **rcr** ***rs***, ***rd***, ***val***  |        **Cyclic right shift with carry**. Shifts right, bit 0 shifts to **C**, old **C** shifts to bit 15.        |       C, Z, N       |         1          |         2         |
 
 ### Compare instructions:
-|              Instruction               |                     Description                       | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: | :----------------: | :---------------: |
-| **cmp** ***rs***, ***rd*** | **Compare**. Performs indestructive subrtaction, sets flags <br> and thus compares numbers in registers ***rs*** and ***rd***. | C, V, Z, N | 1 | 2 |
-| **cmp** ***rs***, ***imm6*** | **Compare with immediate**. Performs indestructive subrtaction, sets flags <br> and thus compares numbers ***rs*** and ***imm6***. | C, V, Z, N | 1 | 2 |
-| **bit** ***rs***, ***rd*** | **Bit test**. Performs indestructive **AND** and sets flags. If any of bits that <br> are set in bitmask ***rd*** are also set in ***rs***, then **Z** is **0**, otherwise **Z** is **1**. | Z, N | 1 | 2 |
+
+|         Instruction          |                                                                                         Description                                                                                         | Flags <br> affected | Time <br> (cycles) | Size <br> (bytes) |
+|:----------------------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-------------------:|:------------------:|:-----------------:|
+|  **cmp** ***rs***, ***rd***  |                               **Compare**. Performs indestructible subtraction, sets flags <br> and thus compares numbers in registers ***rs*** and ***rd***.                               |     C, V, Z, N      |         1          |         2         |
+| **cmp** ***rs***, ***imm6*** |                             **Compare with immediate**. Performs indestructible subtraction, sets flags <br> and thus compares numbers ***rs*** and ***imm6***.                             |     C, V, Z, N      |         1          |         2         |
+|  **bit** ***rs***, ***rd***  | **Bit test**. Performs indestructible **AND** and sets flags. If any of bits that <br> are set in bitmask ***rd*** are also set in ***rs***, then **Z** is **0**, otherwise **Z** is **1**. |        Z, N         |         1          |         2         |
 
 **Macros:**
-|                  Macro                 |                     Description                       |      Expansion      |
-| :------------------------------------: | :---------------------------------------------------: | :-----------------: |
-| **tst** ***rd*** | **Test register**. Compares register with iteself and sets **Z, N** flags according to the result. | **move** ***rd***, ***rd*** | 
 
-
-
-
-
-
-
+|      Macro       |                                            Description                                            |          Expansion          |
+|:----------------:|:-------------------------------------------------------------------------------------------------:|:---------------------------:|
+| **tst** ***rd*** | **Test register**. Compares register with itself and sets **Z, N** flags according to the result. | **move** ***rd***, ***rd*** | 

--- a/logisim/cdm16/cdm16.circ
+++ b/logisim/cdm16/cdm16.circ
@@ -1470,36 +1470,736 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1190,410)" to="(1400,410)"/>
     <wire from="(1170,510)" to="(1190,510)"/>
     <wire from="(820,690)" to="(820,740)"/>
-    <comp lib="1" loc="(130,1780)" name="NOT Gate">
+    <comp lib="0" loc="(1710,1170)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_abs"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(900,1600)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1880,810)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(2120,710)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="address_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1440,520)" name="NOT Gate">
+      <a name="facing" val="west"/>
       <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(1880,950)" name="Tunnel">
+    <comp lib="0" loc="(2110,1660)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1970,820)" name="Tunnel">
+      <a name="label" val="jsr"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2140,600)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(620,1500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="exc_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1130,1630)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1430,1150)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2160,1640)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="imm"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1000,460)" name="Tunnel">
+      <a name="label" val="r_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(700,550)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1160,730)" name="Tunnel">
+      <a name="label" val="imm_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1130)" name="Tunnel">
+      <a name="label" val="r_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(360,1450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1740,670)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ei"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1810,720)" name="Tunnel">
+      <a name="label" val="ps_latch_word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1350,1470)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rs0_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2500,1650)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1260,900)" name="Tunnel">
+      <a name="label" val="alu3_ind"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(340,1700)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1600,570)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+    </comp>
+    <comp lib="0" loc="(250,490)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="ps_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(720,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(970,1570)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1410,1110)" name="Tunnel">
+      <a name="label" val="br_rel_n"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(340,820)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1270,800)" name="Tunnel">
+      <a name="label" val="0op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1530,820)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="width" val="4"/>
       <a name="label" val="op_type_d3"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
+    <comp lib="0" loc="(360,1560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="2"/>
+      <a name="label" val="status"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1710,1250)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(140,1120)" name="Pin">
+      <a name="width" val="6"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="exc_vec"/>
+    </comp>
     <comp lib="2" loc="(720,1480)" name="Multiplexer">
       <a name="width" val="16"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(670,1460)" name="Bit Extender">
-      <a name="in_width" val="3"/>
-    </comp>
-    <comp lib="0" loc="(670,1500)" name="Bit Extender">
-      <a name="in_width" val="6"/>
-    </comp>
-    <comp lib="0" loc="(2690,1250)" name="Tunnel">
-      <a name="label" val="sp_asrt0"/>
+    <comp lib="0" loc="(1410,1020)" name="Tunnel">
+      <a name="label" val="br_abs"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(270,1770)" name="NOR Gate">
+    <comp lib="0" loc="(1160,670)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="imm"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1680,1720)" name="Bit Extender">
+      <a name="in_width" val="6"/>
+      <a name="type" val="one"/>
+    </comp>
+    <comp lib="0" loc="(1920,650)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="ps_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1230,1200)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="4"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(390,1450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(370,590)" name="Pull Resistor">
+      <a name="facing" val="east"/>
+    </comp>
+    <comp lib="0" loc="(880,1240)" name="Tunnel">
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(590,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1710,1230)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3_ind"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2300,1160)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="2"/>
+      <a name="label" val="status"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1370,1590)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2070,1780)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+    </comp>
+    <comp lib="2" loc="(1150,1010)" name="Demultiplexer">
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(1920,820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(1420,450)" name="Tunnel">
+      <a name="label" val="pc_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1200,930)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="XY"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(1580,500)" name="alu"/>
+    <comp lib="5" loc="(1880,540)" name="LED">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(1250,980)" name="Tunnel">
+      <a name="label" val="imm9"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1260,920)" name="Tunnel">
+      <a name="label" val="mem2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1170)" name="Tunnel">
+      <a name="label" val="r_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(720,1200)" name="Register">
+      <a name="width" val="3"/>
+      <a name="trigger" val="high"/>
+    </comp>
+    <comp lib="0" loc="(2410,1800)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_d0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1290)" name="Tunnel">
+      <a name="label" val="sp_dec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(230,1860)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="CUT"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,1770)" name="Tunnel">
+      <a name="label" val="reset_exc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,550)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="rd/wr'"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(620,1560)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x5"/>
+    </comp>
+    <comp lib="0" loc="(2030,1780)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(200,1250)" name="Register">
+      <a name="width" val="6"/>
+    </comp>
+    <comp lib="1" loc="(450,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2190,840)" name="Tunnel">
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1160,1450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Y"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2360,1670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1130,1430)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="2"/>
+      <a name="label" val="XY"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1790,540)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="int_en"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1690,880)" name="Tunnel">
+      <a name="label" val="wait"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2060,610)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="io_phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2370,1710)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x5"/>
+    </comp>
+    <comp lib="0" loc="(1900,1450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1910,1620)" name="Constant">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(80,1520)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2260,1690)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(1790,670)" name="ps_register">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(2460,1560)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="arith_carry"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(2310,1070)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="28"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(2530,1780)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="alu_func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(430,1460)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1640,730)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(1900,730)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="control" val="left"/>
+    </comp>
+    <comp lib="1" loc="(1190,440)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(120,1440)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="hold"/>
+    </comp>
+    <comp lib="0" loc="(2690,1190)" name="Tunnel">
+      <a name="label" val="r_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2140,620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(480,700)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1160,1470)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="X"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2100,800)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="read"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(1360,522)" name="Text">
+      <a name="text" val="PС"/>
+      <a name="font" val="SansSerif bold 20"/>
+    </comp>
+    <comp lib="0" loc="(1360,500)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1660,520)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1900,1480)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1140,1400)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="1" loc="(660,700)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="2" loc="(2070,1690)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1880,490)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="label" val="address_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(970,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="rs1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(2010,1590)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1190,510)" name="Tunnel">
+      <a name="label" val="sp_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2220,1450)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rd_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(710,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1350,1500)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rd_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1410,1200)" name="Tunnel">
+      <a name="label" val="br_rel_p"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1740,1740)" name="Tunnel">
+      <a name="label" val="imm6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(380,1510)" name="Tunnel">
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(2450,1790)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(410,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1880,930)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(370,760)" name="Pull Resistor">
+      <a name="facing" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1980,1720)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(2180,1380)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3_ind"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(770,1250)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1710,1350)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1260,1020)" name="Tunnel">
+      <a name="label" val="alu3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2040,1440)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2050,1060)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="10"/>
+      <a name="incoming" val="10"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="2" loc="(2130,1640)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(120,1680)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="critical_fault"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(140,1770)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(120,1580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,1250)" name="Tunnel">
+      <a name="width" val="6"/>
+      <a name="label" val="int_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1740,1120)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="mem3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,1770)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(450,1710)" name="Tunnel">
+      <a name="label" val="startup"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2340,1120)" name="OR Gate">
+      <a name="facing" val="north"/>
       <a name="size" val="30"/>
       <a name="inputs" val="3"/>
     </comp>
-    <comp lib="1" loc="(1370,1200)" name="AND Gate">
+    <comp lib="6" loc="(1150,522)" name="Text">
+      <a name="text" val="SP"/>
+      <a name="font" val="SansSerif bold 20"/>
+    </comp>
+    <comp lib="0" loc="(130,700)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R5"/>
+    </comp>
+    <comp lib="0" loc="(1120,1570)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(650,1690)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(2310,1690)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="2" loc="(2030,1440)" name="Multiplexer">
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1740,1000)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="0op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(360,1590)" name="Tunnel">
+      <a name="width" val="2"/>
+      <a name="label" val="status"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(120,1600)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="halt"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(470,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="1" loc="(870,1240)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1150,500)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1170,1030)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="X"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(2230,1160)" name="ROM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="28"/>
+      <a name="contents">addr/data: 10 28
+1024*8000000
+</a>
+    </comp>
+    <comp lib="0" loc="(880,1500)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0x8200"/>
+    </comp>
+    <comp lib="1" loc="(310,1500)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(2690,950)" name="Tunnel">
+      <a name="label" val="imm_shift"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2010,1130)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="3"/>
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1390,990)" name="NOT Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(720,1660)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IAck"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(840,700)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(630,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1630,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1740,1020)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="1op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2320,1100)" name="Constant">
+      <a name="width" val="28"/>
+      <a name="value" val="0x8000000"/>
+    </comp>
+    <comp lib="0" loc="(2140,840)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="inc_address"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1160,1540)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="right"/>
+    </comp>
+    <comp lib="0" loc="(1350,1470)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(2260,1690)" name="Splitter">
       <a name="fanout" val="3"/>
@@ -1510,601 +2210,91 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="bit2" val="1"/>
       <a name="bit3" val="2"/>
     </comp>
-    <comp lib="1" loc="(1400,510)" name="AND Gate">
-      <a name="facing" val="west"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(830,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(2690,970)" name="Tunnel">
-      <a name="label" val="mem"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(440,1340)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_trig_ext"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1670,810)" name="Tunnel">
-      <a name="label" val="int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1530,820)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1990,930)" name="Multiplexer">
-      <a name="select" val="3"/>
-      <a name="width" val="4"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(1150,522)" name="Text">
-      <a name="text" val="SP"/>
-      <a name="font" val="SansSerif bold 20"/>
-    </comp>
-    <comp lib="1" loc="(1250,570)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(2010,1130)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="3"/>
-      <a name="label" val="phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(400,550)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(2120,710)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-    </comp>
-    <comp lib="0" loc="(2220,1450)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rd_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1570,970)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="0op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1370,1440)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="shift_count_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(130,700)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R5"/>
-    </comp>
-    <comp lib="1" loc="(1430,1060)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(720,1660)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IAck"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(2310,1690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(3970,2520)" name="Ground"/>
-    <comp lib="0" loc="(1690,860)" name="Tunnel">
-      <a name="label" val="halt"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1160,620)" name="Tunnel">
-      <a name="label" val="imm_asrt1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(700,1720)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(600,700)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1790,540)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="int_en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2500,1650)" name="OR Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2210,550)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="rd/wr'"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(1520,1110)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1520,890)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1190,1230)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="ps_flags"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(1150,510)" name="sp_register">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(180,1270)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="irq"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
     <comp lib="5" loc="(1830,540)" name="LED">
       <a name="facing" val="south"/>
     </comp>
-    <comp lib="1" loc="(1960,820)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(2690,1070)" name="Tunnel">
-      <a name="label" val="ps_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1390,1170)" name="NOT Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="4" loc="(530,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(730,1200)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="exc_internal_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1630,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,1130)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="exc_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1900,730)" name="Controlled Buffer">
+    <comp lib="1" loc="(600,1050)" name="Controlled Buffer">
       <a name="facing" val="south"/>
       <a name="width" val="16"/>
-      <a name="control" val="left"/>
     </comp>
-    <comp lib="0" loc="(250,460)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="pc_value"/>
+    <comp lib="0" loc="(1690,900)" name="Tunnel">
+      <a name="label" val="ei"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(1230,1200)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="1" loc="(980,1600)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(640,550)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(460,550)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1880,890)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="width" val="4"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2040,1440)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_type"/>
+      <a name="label" val="op_type_d1"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(230,1520)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(670,1460)" name="Bit Extender">
+      <a name="in_width" val="3"/>
     </comp>
-    <comp lib="0" loc="(80,1480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="irq"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(180,1150)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="exc_trig_ext"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1210,780)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Y"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,850)" name="Tunnel">
-      <a name="label" val="data"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,1770)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1600,570)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-    </comp>
-    <comp lib="0" loc="(2690,1270)" name="Tunnel">
-      <a name="label" val="sp_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1580,1610)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="9"/>
-      <a name="label" val="imm9_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(840,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(1010,1500)" name="Constant">
       <a name="width" val="16"/>
-    </comp>
-    <comp lib="1" loc="(750,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(340,1790)" name="Tunnel">
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+      <a name="value" val="0x8006"/>
     </comp>
     <comp lib="1" loc="(570,1030)" name="AND Gate">
       <a name="facing" val="south"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="1" loc="(310,1500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(970,440)" name="Tunnel">
+    <comp lib="0" loc="(2160,1490)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="width" val="3"/>
       <a name="label" val="rs0"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(700,550)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="1" loc="(2420,1610)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1880,1710)" name="Constant">
-      <a name="width" val="4"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="0" loc="(1140,1630)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1880,930)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2190,510)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="mem"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(130,640)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R3"/>
-    </comp>
-    <comp lib="0" loc="(340,1720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="CUT"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(570,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(360,1560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="2"/>
-      <a name="label" val="status"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(900,1600)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1120,1590)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="br_rel_flags_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(440,1320)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_trig_div_by_zero"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1210)" name="Tunnel">
-      <a name="label" val="read"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1190,510)" name="Tunnel">
-      <a name="label" val="sp_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1590,600)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="cout"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(660,1780)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2180,1380)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3_ind"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(450,1030)" name="AND Gate">
+    <comp lib="1" loc="(630,1030)" name="AND Gate">
       <a name="facing" val="south"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1370,820)" name="Tunnel">
-      <a name="label" val="br_abs_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp loc="(1260,1210)" name="branch_logic">
       <a name="facing" val="north"/>
     </comp>
-    <comp lib="0" loc="(2120,710)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="address_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="1" loc="(750,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(1830,540)" name="Tunnel">
+    <comp lib="1" loc="(690,840)" name="AND Gate">
       <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(510,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(870,1430)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="latch_int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(700,1660)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="6" loc="(447,1560)" name="Text">
-      <a name="text" val="1 - waiting"/>
-    </comp>
-    <comp lib="2" loc="(1080,960)" name="Decoder">
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="4" loc="(720,1200)" name="Register">
-      <a name="width" val="3"/>
-      <a name="trigger" val="high"/>
-    </comp>
-    <comp lib="0" loc="(660,1180)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1440,520)" name="NOT Gate">
-      <a name="facing" val="west"/>
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(770,1250)" name="Tunnel">
+    <comp lib="0" loc="(360,990)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
+      <a name="label" val="r_asrtD"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(2070,1690)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1350,1500)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1080,1520)" name="Tunnel">
-      <a name="label" val="int_fault"/>
+    <comp lib="0" loc="(2690,1150)" name="Tunnel">
+      <a name="label" val="r_asrt1"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(350,1490)" name="AND Gate">
+    <comp lib="1" loc="(1380,570)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(1140,1430)" name="Splitter">
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(2690,1310)" name="Tunnel">
-      <a name="label" val="sp_inc"/>
+    <comp lib="0" loc="(2300,1040)" name="Tunnel">
+      <a name="label" val="exc_triggered"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1740,1060)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="mem2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1350)" name="Tunnel">
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(150,1200)" name="Tunnel">
+    <comp lib="0" loc="(180,1270)" name="Tunnel">
+      <a name="facing" val="north"/>
       <a name="label" val="irq"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(260,990)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rd"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(450,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(590,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(2160,1640)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="imm"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1740,1080)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="imm6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(790,1440)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(1790,673)" name="Text">
-      <a name="text" val="PS"/>
-      <a name="font" val="SansSerif bold 20"/>
-    </comp>
-    <comp lib="0" loc="(2060,630)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(610,1700)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="int_en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2370,1710)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x5"/>
-    </comp>
-    <comp lib="0" loc="(140,1240)" name="Pin">
-      <a name="width" val="6"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="int_vec"/>
-    </comp>
-    <comp lib="1" loc="(870,1240)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1120,520)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="sp_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(600,1250)" name="Priority Encoder"/>
-    <comp lib="1" loc="(520,550)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(120,1660)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(710,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="2" loc="(1640,910)" name="Decoder">
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(1740,1040)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="2op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(140,1770)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="6" loc="(1360,522)" name="Text">
-      <a name="text" val="PС"/>
-      <a name="font" val="SansSerif bold 20"/>
-    </comp>
-    <comp lib="1" loc="(2180,610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="6" loc="(2050,1818)" name="Text">
-      <a name="text" val="1, 3, 5, 7"/>
-    </comp>
-    <comp lib="0" loc="(620,1560)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x5"/>
-    </comp>
-    <comp lib="0" loc="(1680,1720)" name="Bit Extender">
-      <a name="in_width" val="6"/>
-      <a name="type" val="one"/>
-    </comp>
-    <comp lib="0" loc="(1690,1210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1230)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3_ind"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1210,1170)" name="Tunnel">
@@ -2112,24 +2302,162 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="label" val="br_abs_d"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1730,1200)" name="OR Gate">
+    <comp lib="0" loc="(2190,690)" name="Tunnel">
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1140,1400)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_d1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(350,1490)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(2180,1520)" name="Tunnel">
+    <comp lib="4" loc="(820,1250)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(2190,530)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="imm6"/>
+      <a name="label" val="data"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(870,800)" name="Tunnel">
+    <comp lib="1" loc="(1390,1080)" name="NOT Gate">
       <a name="facing" val="north"/>
-      <a name="label" val="fp_asrt0"/>
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(2180,610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1390,1170)" name="NOT Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(1860,1410)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1920,650)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="ps_value"/>
+    <comp lib="0" loc="(1740,1060)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="mem2"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(150,1090)" name="Tunnel">
+      <a name="label" val="exc_trig_ext"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(770,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="1" loc="(1520,1110)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(210,490)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="PS"/>
+    </comp>
+    <comp lib="4" loc="(180,1420)" name="D Flip-Flop">
+      <a name="trigger" val="low"/>
+    </comp>
+    <comp lib="1" loc="(700,1660)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2690,1370)" name="Tunnel">
+      <a name="label" val="CUT"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,510)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="mem"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="3" loc="(1960,1610)" name="Shifter">
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(1140,610)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(2390,1090)" name="Splitter">
+      <a name="fanout" val="28"/>
+      <a name="incoming" val="28"/>
+      <a name="appear" val="right"/>
+    </comp>
+    <comp lib="0" loc="(1350,1590)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1590,600)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="cout"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(1000,1540)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="3" loc="(2180,980)" name="Comparator">
+      <a name="width" val="28"/>
+    </comp>
+    <comp lib="0" loc="(1640,470)" name="Tunnel">
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1210)" name="Tunnel">
+      <a name="label" val="read"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(140,1240)" name="Pin">
+      <a name="width" val="6"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="int_vec"/>
+    </comp>
+    <comp lib="0" loc="(1420,470)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="pc_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(980,700)" name="Decoder">
+      <a name="facing" val="west"/>
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="1" loc="(600,700)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="2" loc="(1590,450)" name="Multiplexer">
+      <a name="facing" val="west"/>
+      <a name="selloc" val="tr"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(2290,1220)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(2160,780)" name="bus_control">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(660,1780)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(640,1210)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x6"/>
     </comp>
     <comp lib="0" loc="(1190,1190)" name="Tunnel">
       <a name="facing" val="east"/>
@@ -2137,62 +2465,21 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="label" val="br_rel_flags_d"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1820,630)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="ps_flags"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(380,1690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(1370,1110)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1340,580)" name="Tunnel">
+    <comp lib="0" loc="(1710,1330)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="pc_asrtD"/>
+      <a name="label" val="br_rel_nop"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1410,1020)" name="Tunnel">
-      <a name="label" val="br_abs"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(200,1250)" name="Register">
-      <a name="width" val="6"/>
-    </comp>
-    <comp lib="0" loc="(1260,940)" name="Tunnel">
-      <a name="label" val="alu2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1900,1450)" name="Tunnel">
+    <comp lib="0" loc="(370,410)" name="Pull Resistor">
       <a name="facing" val="east"/>
-      <a name="label" val="alu2"/>
+    </comp>
+    <comp lib="0" loc="(1440,970)" name="Tunnel">
+      <a name="label" val="br_abs_nop"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1160,670)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="imm"/>
+    <comp lib="0" loc="(2190,860)" name="Tunnel">
+      <a name="label" val="io_phase"/>
       <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(840,700)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(80,1500)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_trig_ext"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(420,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(2010,1060)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(1880,910)" name="Tunnel">
       <a name="facing" val="east"/>
@@ -2200,39 +2487,239 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="label" val="op_type_d2"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(130,1500)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="5" loc="(1880,540)" name="LED">
+    <comp lib="0" loc="(1280,1320)" name="Tunnel">
       <a name="facing" val="south"/>
-    </comp>
-    <comp lib="1" loc="(1620,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(2220,750)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="data_out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(2140,620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(2690,1010)" name="Tunnel">
-      <a name="label" val="pc_asrtD"/>
+      <a name="width" val="9"/>
+      <a name="label" val="imm9_d"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp loc="(1580,500)" name="alu"/>
+    <comp lib="0" loc="(1920,1100)" name="Bit Extender">
+      <a name="in_width" val="3"/>
+      <a name="out_width" val="4"/>
+    </comp>
+    <comp lib="2" loc="(2360,1090)" name="Multiplexer">
+      <a name="width" val="28"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(440,1460)" name="Tunnel">
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1210,450)" name="Tunnel">
+      <a name="label" val="sp_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(1360,510)" name="pc_register">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="1" loc="(700,1280)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(1490,570)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(130,640)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R3"/>
+    </comp>
+    <comp lib="2" loc="(1750,1660)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(830,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1140,1630)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="1" loc="(780,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1190,1210)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="br_abs_flags_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1770,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ps_latch_flags"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(190,1760)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="3"/>
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(650,1650)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1260,940)" name="Tunnel">
+      <a name="label" val="alu2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2220,800)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="data_in"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1210,780)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Y"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(620,1540)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="exc_internal_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,990)" name="Tunnel">
+      <a name="label" val="pc_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(800,1480)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0x8000"/>
+    </comp>
+    <comp lib="0" loc="(440,1300)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_trig_invalid_inst"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(750,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
     <comp lib="1" loc="(390,1030)" name="AND Gate">
       <a name="facing" val="south"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(1900,1480)" name="Tunnel">
+    <comp lib="0" loc="(1140,1590)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="1" loc="(380,1690)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1370,1570)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="br_abs_flags_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2010,1060)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1920,720)" name="Tunnel">
+      <a name="label" val="ps_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1330,520)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="shifts"/>
+      <a name="label" val="pc_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,870)" name="Tunnel">
+      <a name="label" val="fp_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(130,760)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="FP"/>
+    </comp>
+    <comp lib="2" loc="(2170,1490)" name="Multiplexer">
+      <a name="facing" val="west"/>
+      <a name="width" val="3"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(270,980)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(580,550)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(2350,1600)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(640,1730)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2420,1570)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(780,700)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(870,800)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="fp_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1590,820)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="1" loc="(1370,1200)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(660,1180)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="3" loc="(1060,1510)" name="Comparator">
+      <a name="width" val="16"/>
+      <a name="mode" val="unsigned"/>
+    </comp>
+    <comp lib="1" loc="(450,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1580,1610)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="9"/>
+      <a name="label" val="imm9_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1440,500)" name="Tunnel">
+      <a name="label" val="pc_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1740,1100)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="imm9"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1830,650)" name="Splitter">
@@ -2257,590 +2744,90 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="bit14" val="none"/>
       <a name="bit15" val="none"/>
     </comp>
-    <comp lib="0" loc="(1590,580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="CVZN"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1130,1430)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="2"/>
-      <a name="label" val="XY"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(270,1500)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(1620,950)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(2410,1800)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_d0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1360,500)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="16"/>
-    </comp>
-    <comp lib="1" loc="(1640,730)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1970,500)" name="Pin">
+    <comp lib="2" loc="(2170,1410)" name="Multiplexer">
       <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="address"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1660,540)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="shift_count_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(970,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rs1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,490)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="PS"/>
-    </comp>
-    <comp lib="1" loc="(480,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1360,1630)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1570,880)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(2050,1060)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="10"/>
-      <a name="incoming" val="10"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(120,1580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(200,1130)" name="Register">
-      <a name="width" val="6"/>
-    </comp>
-    <comp lib="0" loc="(1240,560)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="sp_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="3" loc="(1930,1700)" name="Shifter">
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1160,800)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="X"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1740,1020)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="1op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1580,420)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="arith_carry"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(441,1585)" name="Text">
-      <a name="text" val="3 - fault"/>
-    </comp>
-    <comp lib="0" loc="(1280,1330)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="fanout" val="9"/>
-      <a name="incoming" val="9"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="2" loc="(1150,1010)" name="Demultiplexer">
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1460,540)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_rel_nop"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(370,590)" name="Pull Resistor">
-      <a name="facing" val="east"/>
-    </comp>
-    <comp lib="2" loc="(980,700)" name="Decoder">
-      <a name="facing" val="west"/>
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(2350,1620)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3_ind"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1350,1440)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="2" loc="(1200,810)" name="Demultiplexer">
       <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1340,560)" name="Tunnel">
+    <comp lib="0" loc="(1820,820)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="jsr"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(120,1400)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="clock"/>
-    </comp>
-    <comp lib="0" loc="(1480,560)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="pc_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(780,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(2220,1400)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rs1_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1690,920)" name="Tunnel">
-      <a name="label" val="di"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2100,800)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="read"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1140,610)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(2690,1150)" name="Tunnel">
-      <a name="label" val="r_asrt1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1370,1590)" name="Tunnel">
       <a name="width" val="4"/>
       <a name="label" val="op_type_d0"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1770,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ps_latch_flags"/>
+    <comp lib="2" loc="(1150,830)" name="Demultiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(2690,850)" name="Tunnel">
+      <a name="label" val="data"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1990,1490)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="2" loc="(340,1560)" name="Priority Encoder">
-      <a name="select" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1740,1100)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="imm9"/>
+    <comp lib="0" loc="(1690,450)" name="Tunnel">
+      <a name="label" val="inc_address"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1150,500)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1640,470)" name="Tunnel">
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(580,550)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
+    <comp lib="2" loc="(940,1470)" name="Multiplexer">
       <a name="width" val="16"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1140,530)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(450,1547)" name="Text">
-      <a name="text" val="0 - running"/>
-    </comp>
-    <comp lib="0" loc="(1350,1470)" name="Splitter">
-      <a name="facing" val="west"/>
+    <comp lib="0" loc="(1540,820)" name="Splitter">
       <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1370,1570)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="br_abs_flags_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1980,1420)" name="Constant">
-      <a name="width" val="3"/>
-    </comp>
-    <comp lib="0" loc="(1860,1410)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1860,1430)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3_ind"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1250)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(820,550)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="6" loc="(1789,595)" name="Text">
-      <a name="text" val="CVZN"/>
-    </comp>
-    <comp lib="1" loc="(750,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(2230,1060)" name="ROM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="28"/>
-      <a name="contents">addr/data: 10 28
-4*0 4*c000000 4a00282 5280882 ca00282 d280882 ce00082 e280082
-ca01082 d284082 ca20082 d2c0082 c0c0580 4a00282 8440000 a020000
-8041000 8024000 8040200 8020800 6*0 804a001 15*0 c0c8082
-80c8082 81c8082 c0c8080 80c8080 81c8080 c028082 8028082 8*0
-c0c00ce c0c00ee 80c00ce 80c00ee 81c00ce 81c00ee c0200ce c0200ee
-80200ce 80200ee 8040010 8040030 804a009 804a029 800a008 800a028
-4a01082 4080888 ca00092 ca000b2 a200049 a200069 4a00282 4a00282
-8*0 c0d8082 80d8082 81d8082 c0d8080 80d8080 81d8080 c038082
-8038082 8*0 c080980 804a001 801a000 805a001 8000949 8000969
-8000400 c080580 16*0 c080980 d284082 9*0 8020800 60*0
-4a00282 c084088 4*0 8000949 8000969 120*0 4080888 127*0
-c084088
-</a>
-    </comp>
-    <comp lib="0" loc="(1740,690)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="di"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2110,1660)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1530,1110)" name="Tunnel">
-      <a name="label" val="br_rel_nop"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1920,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(2190,710)" name="Tunnel">
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1190,440)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1160,1540)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1710,1330)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_rel_nop"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,730)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R6"/>
-    </comp>
-    <comp lib="0" loc="(340,820)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(150,1090)" name="Tunnel">
-      <a name="label" val="exc_trig_ext"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,890)" name="Tunnel">
-      <a name="label" val="imm_asrt1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1180,900)" name="Demultiplexer">
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(1390,990)" name="NOT Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(810,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2190,840)" name="Tunnel">
-      <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(360,1590)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="status"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(480,700)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(2210,610)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="word"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(360,990)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="r_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(720,1400)" name="Bit Extender">
-      <a name="in_width" val="6"/>
-    </comp>
-    <comp lib="0" loc="(1740,1740)" name="Tunnel">
-      <a name="label" val="imm6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2330,1210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(460,550)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1350,1590)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
       <a name="incoming" val="4"/>
       <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="1"/>
+      <a name="bit3" val="2"/>
     </comp>
-    <comp lib="1" loc="(1580,950)" name="NOT Gate">
-      <a name="size" val="20"/>
+    <comp lib="0" loc="(1580,1700)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="imm6_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1490,570)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="1" loc="(740,1270)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1550,500)" name="Tunnel">
+    <comp lib="0" loc="(620,1460)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="width" val="3"/>
-      <a name="label" val="alu_func"/>
+      <a name="label" val="exc_internal_vec"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(80,1520)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1660,810)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(1750,1660)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1370,1420)" name="Tunnel">
+    <comp lib="0" loc="(1370,1440)" name="Tunnel">
       <a name="width" val="3"/>
-      <a name="label" val="rs1_d"/>
+      <a name="label" val="shift_count_d"/>
       <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1690,880)" name="Tunnel">
-      <a name="label" val="wait"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(2170,1490)" name="Multiplexer">
-      <a name="facing" val="west"/>
-      <a name="width" val="3"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp loc="(1360,510)" name="pc_register">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1160,730)" name="Tunnel">
-      <a name="label" val="imm_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1690,1190)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2260,1690)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1310)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_abs_nop"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,670)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R4"/>
-    </comp>
-    <comp lib="0" loc="(2190,980)" name="Tunnel">
-      <a name="label" val="exc_trig_invalid_inst"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1880,540)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1260,880)" name="Tunnel">
-      <a name="label" val="2op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1660,520)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(150,1790)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(170,1770)" name="Counter">
-      <a name="width" val="3"/>
-      <a name="max" val="0x7"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(1440,500)" name="Tunnel">
-      <a name="label" val="pc_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,870)" name="Tunnel">
-      <a name="label" val="fp_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2190,860)" name="Tunnel">
-      <a name="label" val="io_phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2300,1160)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="2"/>
-      <a name="label" val="status"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1330,520)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="pc_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1830,670)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1350)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(470,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(650,1650)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1170,1030)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="X"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(2230,1160)" name="ROM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="28"/>
-      <a name="contents">addr/data: 10 28
-1024*8000000
-</a>
-    </comp>
-    <comp lib="0" loc="(2300,1040)" name="Tunnel">
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1680,1590)" name="Bit Extender">
-      <a name="in_width" val="9"/>
-    </comp>
-    <comp lib="0" loc="(1350,1630)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(2130,970)" name="Constant">
       <a name="width" val="28"/>
       <a name="value" val="0x0"/>
     </comp>
-    <comp lib="0" loc="(2690,1330)" name="Tunnel">
-      <a name="label" val="sp_latch"/>
+    <comp lib="0" loc="(1620,800)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="imm9"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2190,530)" name="Tunnel">
+    <comp lib="0" loc="(2690,1270)" name="Tunnel">
+      <a name="label" val="sp_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(400,550)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(270,1770)" name="NOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(340,1790)" name="Tunnel">
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2290,1200)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="data"/>
+      <a name="label" val="latch_int"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(2160,1410)" name="Tunnel">
@@ -2849,133 +2836,107 @@ c084088
       <a name="label" val="rs1"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(880,1500)" name="Constant">
-      <a name="width" val="16"/>
-      <a name="value" val="0x8200"/>
+    <comp loc="(1150,510)" name="sp_register">
+      <a name="facing" val="north"/>
     </comp>
-    <comp lib="0" loc="(640,1730)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_triggered"/>
+    <comp lib="0" loc="(1670,810)" name="Tunnel">
+      <a name="label" val="int"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(760,550)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
+    <comp lib="4" loc="(180,1580)" name="D Flip-Flop"/>
+    <comp lib="1" loc="(660,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
       <a name="width" val="16"/>
     </comp>
-    <comp lib="0" loc="(640,1210)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x6"/>
+    <comp lib="0" loc="(2190,980)" name="Tunnel">
+      <a name="label" val="exc_trig_invalid_inst"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(610,1680)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="irq"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1430,970)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(670,1400)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="int_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1230)" name="Tunnel">
+      <a name="label" val="sign_extend"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1000,710)" name="Tunnel">
+      <a name="label" val="r_asrt1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1570,970)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="0op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1260,840)" name="Tunnel">
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1280,1330)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="fanout" val="9"/>
+      <a name="incoming" val="9"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="2" loc="(1080,960)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1710,1290)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_rel_n"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2190,510)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="mem"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1730,1690)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(870,1430)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="latch_int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(650,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="6" loc="(1790,673)" name="Text">
+      <a name="text" val="PS"/>
+      <a name="font" val="SansSerif bold 20"/>
+    </comp>
+    <comp lib="4" loc="(180,1660)" name="D Flip-Flop"/>
+    <comp lib="1" loc="(1730,1200)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(510,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="1" loc="(320,1800)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="2" loc="(2310,1070)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="28"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1880,890)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1130)" name="Tunnel">
-      <a name="label" val="r_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(270,980)" name="Decoder">
-      <a name="select" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(640,550)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(370,760)" name="Pull Resistor">
-      <a name="facing" val="east"/>
-    </comp>
-    <comp lib="1" loc="(2420,1570)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(2010,1590)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(2030,1440)" name="Multiplexer">
-      <a name="width" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(90,1770)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="CUT"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(440,1300)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_trig_invalid_inst"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(250,430)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="sp_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,830)" name="Tunnel">
-      <a name="label" val="alu_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1880,490)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="label" val="address_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1580,1700)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="imm6_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(700,1770)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1740,1000)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="0op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1350,530)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2210,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="data/ins'"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(180,1660)" name="D Flip-Flop"/>
-    <comp lib="1" loc="(430,1460)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(340,1810)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="fetch"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1250,980)" name="Tunnel">
-      <a name="label" val="imm9"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1430,1150)" name="AND Gate">
+    <comp lib="1" loc="(2330,1210)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
@@ -3001,501 +2962,163 @@ c084088
       <a name="bit14" val="none"/>
       <a name="bit15" val="0"/>
     </comp>
-    <comp lib="0" loc="(2690,1050)" name="Tunnel">
-      <a name="label" val="pc_latch"/>
+    <comp lib="0" loc="(1080,1520)" name="Tunnel">
+      <a name="label" val="int_fault"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2000,1630)" name="Tunnel">
-      <a name="label" val="imm_shift"/>
+    <comp lib="0" loc="(1120,520)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="sp_latch"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2690,1170)" name="Tunnel">
-      <a name="label" val="r_asrtD"/>
+    <comp lib="0" loc="(1820,630)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="ps_flags"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(800,1480)" name="Constant">
-      <a name="width" val="16"/>
-      <a name="value" val="0x8000"/>
+    <comp lib="0" loc="(1530,1110)" name="Tunnel">
+      <a name="label" val="br_rel_nop"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(390,1450)" name="NOT Gate">
+    <comp lib="0" loc="(2690,1330)" name="Tunnel">
+      <a name="label" val="sp_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1620,820)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(1530,890)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="1" loc="(810,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(1140,740)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="control" val="left"/>
-    </comp>
-    <comp lib="1" loc="(390,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(2360,1670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2370,1730)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x6"/>
-    </comp>
-    <comp lib="0" loc="(720,1720)" name="Tunnel">
-      <a name="label" val="latch_int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1390,1080)" name="NOT Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(2690,1090)" name="Tunnel">
-      <a name="label" val="ps_latch_flags"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(880,1240)" name="Tunnel">
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2220,800)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="data_in"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1350,1350)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="imm6_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1120,1570)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1840,1060)" name="Priority Encoder"/>
-    <comp lib="0" loc="(670,1400)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="int_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1200,930)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="XY"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2350,1580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1160,1450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Y"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,950)" name="Tunnel">
-      <a name="label" val="imm_shift"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="3" loc="(1060,1510)" name="Comparator">
-      <a name="width" val="16"/>
-      <a name="mode" val="unsigned"/>
-    </comp>
-    <comp lib="0" loc="(1740,1720)" name="Tunnel">
-      <a name="label" val="imm_extend_negative"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2290,1220)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(440,1460)" name="Tunnel">
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1290)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_rel_n"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1680,1680)" name="Bit Extender">
-      <a name="in_width" val="6"/>
-    </comp>
-    <comp lib="0" loc="(620,1500)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="exc_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(340,1700)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1590,820)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(1000,460)" name="Tunnel">
-      <a name="label" val="r_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1260,1020)" name="Tunnel">
-      <a name="label" val="alu3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(130,760)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="FP"/>
-    </comp>
-    <comp lib="0" loc="(2160,1490)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rs0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1680,1630)" name="Bit Extender">
-      <a name="in_width" val="9"/>
-      <a name="type" val="one"/>
-    </comp>
-    <comp lib="0" loc="(1130,1630)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2020,1710)" name="OR Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1880,990)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1910,1620)" name="Constant">
-      <a name="width" val="4"/>
-    </comp>
-    <comp lib="0" loc="(1750,640)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="CVZN"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1110)" name="Tunnel">
-      <a name="label" val="ps_latch_word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(190,1760)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="3"/>
-      <a name="label" val="phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(140,1090)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="EXC"/>
-    </comp>
-    <comp lib="5" loc="(1790,540)" name="LED">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1690,450)" name="Tunnel">
-      <a name="label" val="inc_address"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1920,720)" name="Tunnel">
-      <a name="label" val="ps_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2030,1780)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(650,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(2350,1600)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1440,970)" name="Tunnel">
-      <a name="label" val="br_abs_nop"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(820,1250)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(1350,1470)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rs0_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1400,440)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(690,1310)" name="Tunnel">
-      <a name="label" val="reset_exc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2300,1650)" name="Tunnel">
+    <comp lib="0" loc="(1740,1080)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="imm6"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2010,1030)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1690,430)" name="Tunnel">
-      <a name="label" val="mem"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1150,830)" name="Demultiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="4" loc="(1000,1540)" name="Register">
+    <comp lib="1" loc="(540,700)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
       <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
     </comp>
-    <comp lib="0" loc="(880,1180)" name="Tunnel">
-      <a name="label" val="critical_fault"/>
+    <comp lib="0" loc="(720,1720)" name="Tunnel">
+      <a name="label" val="latch_int"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="1" loc="(2100,620)" name="OR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(2190,690)" name="Tunnel">
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1410,1200)" name="Tunnel">
-      <a name="label" val="br_rel_p"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1260,1000)" name="Tunnel">
-      <a name="label" val="mem3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1260,900)" name="Tunnel">
-      <a name="label" val="alu3_ind"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(230,1860)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="CUT"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1250,860)" name="Tunnel">
-      <a name="label" val="1op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(970,1570)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_abs"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1210,470)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="sp_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(770,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(1620,800)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="imm9"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1270,800)" name="Tunnel">
-      <a name="label" val="0op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1810,720)" name="Tunnel">
-      <a name="label" val="ps_latch_word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(2450,1790)" name="Multiplexer">
+    <comp lib="2" loc="(890,1460)" name="Multiplexer">
       <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
+      <a name="width" val="16"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1140,1400)" name="Splitter">
+    <comp lib="2" loc="(790,1440)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1140,1500)" name="Splitter">
       <a name="fanout" val="3"/>
       <a name="incoming" val="3"/>
       <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(370,410)" name="Pull Resistor">
-      <a name="facing" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1280,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="9"/>
-      <a name="label" val="imm9_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1540,820)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="2"/>
-    </comp>
-    <comp lib="2" loc="(2520,1780)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp loc="(1790,670)" name="ps_register">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1160,1470)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="X"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(980,470)" name="Decoder">
-      <a name="facing" val="west"/>
-      <a name="selloc" val="tr"/>
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp loc="(2160,780)" name="bus_control">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1920,1100)" name="Bit Extender">
-      <a name="in_width" val="3"/>
-      <a name="out_width" val="4"/>
-    </comp>
-    <comp lib="0" loc="(1210,450)" name="Tunnel">
-      <a name="label" val="sp_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1830,820)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(2300,1180)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="startup"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,610)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R2"/>
-    </comp>
-    <comp lib="0" loc="(2690,1190)" name="Tunnel">
-      <a name="label" val="r_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(600,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1910,790)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="0op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(180,1500)" name="D Flip-Flop"/>
-    <comp lib="1" loc="(870,1180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(180,1420)" name="D Flip-Flop">
-      <a name="trigger" val="low"/>
-    </comp>
-    <comp lib="2" loc="(2130,1640)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2160,1450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rd"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(280,1540)" name="Constant"/>
-    <comp lib="0" loc="(1860,670)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="int_en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(250,490)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="ps_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(690,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1140,1400)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_d1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1740,1120)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="mem3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1790,720)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1710,1270)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_rel_p"/>
+    <comp lib="0" loc="(1350,1440)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="6" loc="(2050,1818)" name="Text">
+      <a name="text" val="1, 3, 5, 7"/>
+    </comp>
+    <comp lib="1" loc="(510,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1430,1060)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1370,1110)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1400,510)" name="AND Gate">
+      <a name="facing" val="west"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(870,1180)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(250,1810)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="1" loc="(690,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2690,1090)" name="Tunnel">
+      <a name="label" val="ps_latch_flags"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(820,1170)" name="Tunnel">
+    <comp lib="0" loc="(2410,1780)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="int_fault"/>
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_d1"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2690,1230)" name="Tunnel">
-      <a name="label" val="sign_extend"/>
+    <comp lib="0" loc="(730,1200)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="exc_internal_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(360,880)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="r_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(770,1410)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(120,1660)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(700,1770)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2690,830)" name="Tunnel">
+      <a name="label" val="alu_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1350,1500)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(2220,1400)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rs1_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1370,820)" name="Tunnel">
+      <a name="label" val="br_abs_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1140,530)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(950,1550)" name="Tunnel">
@@ -3503,44 +3126,88 @@ c084088
       <a name="label" val="fetch"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(630,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(140,1200)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="IRQ"/>
-    </comp>
-    <comp lib="1" loc="(840,1470)" name="OR Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(360,1450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_inhibit"/>
+    <comp lib="0" loc="(2690,1310)" name="Tunnel">
+      <a name="label" val="sp_inc"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(2360,1090)" name="Multiplexer">
-      <a name="width" val="28"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1740,670)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ei"/>
+    <comp lib="0" loc="(1860,670)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="int_en"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(130,580)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R1"/>
+    <comp lib="4" loc="(200,1130)" name="Register">
+      <a name="width" val="6"/>
     </comp>
-    <comp lib="2" loc="(2410,1720)" name="Multiplexer">
+    <comp lib="2" loc="(980,470)" name="Decoder">
+      <a name="facing" val="west"/>
       <a name="selloc" val="tr"/>
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(1210,470)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="sp_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1340,580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="pc_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(440,1340)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_trig_ext"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1660,540)" name="Tunnel">
       <a name="width" val="3"/>
-      <a name="enable" val="false"/>
+      <a name="label" val="shift_count_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1190,530)" name="Tunnel">
+      <a name="label" val="sp_dec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2120,710)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+    </comp>
+    <comp lib="0" loc="(1550,500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="alu_func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(530,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1860,1430)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3_ind"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,610)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="word"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(1880,870)" name="Tunnel">
       <a name="facing" val="east"/>
@@ -3548,84 +3215,154 @@ c084088
       <a name="label" val="op_type_d0"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1350,1500)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rd_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2010,1110)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-    </comp>
-    <comp lib="0" loc="(620,1540)" name="Tunnel">
+    <comp lib="0" loc="(210,1810)" name="Tunnel">
       <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="5" loc="(1790,540)" name="LED">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(1140,1430)" name="Splitter">
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="1" loc="(760,550)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(2010,1030)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1120,1590)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="br_rel_flags_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1460,540)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_rel_nop"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1690,1210)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1880,990)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1240,560)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="sp_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(840,1470)" name="OR Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(210,610)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R2"/>
+    </comp>
+    <comp lib="0" loc="(1680,1680)" name="Bit Extender">
+      <a name="in_width" val="6"/>
+    </comp>
+    <comp lib="6" loc="(450,1547)" name="Text">
+      <a name="text" val="0 - running"/>
+    </comp>
+    <comp lib="0" loc="(1530,890)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="3" loc="(670,1550)" name="Comparator">
       <a name="width" val="3"/>
-      <a name="label" val="exc_internal_vec"/>
+      <a name="mode" val="unsigned"/>
+    </comp>
+    <comp lib="2" loc="(1990,930)" name="Multiplexer">
+      <a name="select" val="3"/>
+      <a name="width" val="4"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1690,920)" name="Tunnel">
+      <a name="label" val="di"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1260,920)" name="Tunnel">
-      <a name="label" val="mem2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(540,1050)" name="Controlled Buffer">
+    <comp lib="1" loc="(1250,570)" name="Controlled Buffer">
       <a name="facing" val="south"/>
       <a name="width" val="16"/>
     </comp>
-    <comp lib="1" loc="(630,840)" name="AND Gate">
+    <comp lib="0" loc="(1830,670)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="3" loc="(2180,980)" name="Comparator">
-      <a name="width" val="28"/>
-    </comp>
-    <comp lib="0" loc="(1690,900)" name="Tunnel">
-      <a name="label" val="ei"/>
+      <a name="label" val="cin"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(510,840)" name="AND Gate">
+    <comp lib="0" loc="(920,1490)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1260,840)" name="Tunnel">
-      <a name="label" val="shifts"/>
+      <a name="label" val="startup"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(1590,450)" name="Multiplexer">
-      <a name="facing" val="west"/>
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2690,990)" name="Tunnel">
-      <a name="label" val="pc_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,930)" name="Tunnel">
-      <a name="label" val="imm_extend_negative"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(380,1510)" name="Tunnel">
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2090,790)" name="Controlled Buffer">
-      <a name="facing" val="west"/>
-      <a name="width" val="16"/>
-      <a name="control" val="left"/>
-    </comp>
-    <comp lib="1" loc="(1380,570)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2350,1560)" name="Tunnel">
+    <comp lib="0" loc="(1160,800)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="shifts"/>
+      <a name="label" val="X"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2530,1780)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="alu_func"/>
+    <comp lib="0" loc="(2690,1030)" name="Tunnel">
+      <a name="label" val="pc_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1350,1350)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+    </comp>
+    <comp lib="0" loc="(690,1310)" name="Tunnel">
+      <a name="label" val="reset_exc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,730)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R6"/>
+    </comp>
+    <comp lib="0" loc="(1710,1270)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_rel_p"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1650,440)" name="AND Gate">
+      <a name="facing" val="west"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(230,1520)" name="OR Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(250,460)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="pc_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(740,1270)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(340,1560)" name="Priority Encoder">
+      <a name="select" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2690,1050)" name="Tunnel">
+      <a name="label" val="pc_latch"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1600,580)" name="Splitter">
@@ -3638,332 +3375,214 @@ c084088
       <a name="bit2" val="none"/>
       <a name="bit3" val="0"/>
     </comp>
-    <comp lib="0" loc="(1370,1400)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_d0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(980,1600)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(120,1440)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="hold"/>
-    </comp>
-    <comp lib="0" loc="(620,1460)" name="Tunnel">
+    <comp lib="0" loc="(1520,890)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="exc_internal_vec"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d0"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(700,1280)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(720,1050)" name="Controlled Buffer">
+    <comp lib="1" loc="(480,1050)" name="Controlled Buffer">
       <a name="facing" val="south"/>
       <a name="width" val="16"/>
     </comp>
-    <comp lib="0" loc="(1970,820)" name="Tunnel">
-      <a name="label" val="jsr"/>
+    <comp lib="4" loc="(430,1690)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(120,1400)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="clock"/>
+    </comp>
+    <comp lib="0" loc="(2690,930)" name="Tunnel">
+      <a name="label" val="imm_extend_negative"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1140,740)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="control" val="left"/>
+    </comp>
+    <comp lib="0" loc="(2300,1160)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="0"/>
+    </comp>
+    <comp lib="0" loc="(80,1500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_trig_ext"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2350,1580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(940,1610)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(2090,790)" name="Controlled Buffer">
+      <a name="facing" val="west"/>
+      <a name="width" val="16"/>
+      <a name="control" val="left"/>
+    </comp>
+    <comp lib="0" loc="(2690,890)" name="Tunnel">
+      <a name="label" val="imm_asrt1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1980,1420)" name="Constant">
+      <a name="width" val="3"/>
+    </comp>
+    <comp lib="1" loc="(570,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(2190,550)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="read"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(780,700)" name="Controlled Buffer">
+    <comp lib="0" loc="(2690,1350)" name="Tunnel">
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(130,1500)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(1350,530)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="width" val="16"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2390,1090)" name="Splitter">
-      <a name="fanout" val="28"/>
-      <a name="incoming" val="28"/>
-      <a name="appear" val="right"/>
+    <comp lib="0" loc="(2690,970)" name="Tunnel">
+      <a name="label" val="mem"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1730,1690)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="appear" val="center"/>
+    <comp lib="0" loc="(1340,560)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="jsr"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="1" loc="(880,790)" name="Controlled Buffer">
       <a name="width" val="16"/>
     </comp>
-    <comp lib="3" loc="(1960,1610)" name="Shifter">
-      <a name="width" val="16"/>
+    <comp lib="0" loc="(1680,1630)" name="Bit Extender">
+      <a name="in_width" val="9"/>
+      <a name="type" val="one"/>
     </comp>
-    <comp lib="1" loc="(720,700)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
+    <comp lib="0" loc="(150,1200)" name="Tunnel">
+      <a name="label" val="irq"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="3" loc="(670,1550)" name="Comparator">
+    <comp lib="0" loc="(1590,580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="CVZN"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1960,820)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(1260,880)" name="Tunnel">
+      <a name="label" val="2op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(970,440)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="width" val="3"/>
-      <a name="mode" val="unsigned"/>
+      <a name="label" val="rs0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(610,1680)" name="Tunnel">
+    <comp lib="0" loc="(1880,950)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(810,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(80,1480)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="irq"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2690,1030)" name="Tunnel">
-      <a name="label" val="pc_inc"/>
+    <comp lib="0" loc="(820,1170)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="int_fault"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(540,700)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
+    <comp lib="1" loc="(420,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
       <a name="width" val="16"/>
     </comp>
-    <comp lib="2" loc="(2170,1410)" name="Multiplexer">
+    <comp lib="0" loc="(2210,530)" name="Pin">
       <a name="facing" val="west"/>
-      <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
+      <a name="output" val="true"/>
+      <a name="label" val="data/ins'"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="1" loc="(650,1690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(340,1810)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="fetch"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(410,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(2690,910)" name="Tunnel">
-      <a name="label" val="imm_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(180,1580)" name="D Flip-Flop"/>
-    <comp lib="0" loc="(720,1770)" name="Tunnel">
-      <a name="label" val="reset_exc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(920,1490)" name="Tunnel">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(2300,1180)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="startup"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(660,700)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1980,1720)" name="Constant">
-      <a name="width" val="16"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="4" loc="(250,1810)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="4" loc="(430,1690)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(770,1410)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1420,470)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="pc_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1650,440)" name="AND Gate">
-      <a name="facing" val="west"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2070,1780)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1000,710)" name="Tunnel">
-      <a name="label" val="r_asrt1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1760,1320)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2220,1480)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rs0_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2120,730)" name="Tunnel">
+    <comp lib="2" loc="(1840,1220)" name="Priority Encoder"/>
+    <comp lib="0" loc="(2300,1650)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="sign_extend"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(940,1610)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(1140,1500)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="1" loc="(1370,1020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1140,1590)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1190,1210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="br_abs_flags_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1820,820)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1410,1110)" name="Tunnel">
-      <a name="label" val="br_rel_n"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1370)" name="Tunnel">
-      <a name="label" val="CUT"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(680,1200)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(210,430)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="SP"/>
-    </comp>
-    <comp lib="0" loc="(1160,1540)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="right"/>
-    </comp>
-    <comp lib="0" loc="(120,1530)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="wait"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1290)" name="Tunnel">
-      <a name="label" val="sp_dec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(120,1680)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="critical_fault"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1350,1350)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-    </comp>
-    <comp lib="0" loc="(1790,620)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="labelfont" val="SansSerif plain 16"/>
-    </comp>
-    <comp lib="0" loc="(120,1600)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="halt"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2290,1200)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="latch_int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2060,610)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="io_phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,550)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R0"/>
-    </comp>
-    <comp lib="0" loc="(140,1120)" name="Pin">
-      <a name="width" val="6"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="exc_vec"/>
-    </comp>
-    <comp lib="0" loc="(1190,530)" name="Tunnel">
-      <a name="label" val="sp_dec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(446,1572)" name="Text">
-      <a name="text" val="2 - halted"/>
-    </comp>
-    <comp lib="0" loc="(2140,600)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2210,510)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="mem"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1420,450)" name="Tunnel">
-      <a name="label" val="pc_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1250,960)" name="Tunnel">
       <a name="label" val="imm6"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(2050,1720)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(2370,1730)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x6"/>
     </comp>
-    <comp lib="0" loc="(360,880)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="r_latch"/>
+    <comp lib="0" loc="(1250,860)" name="Tunnel">
+      <a name="label" val="1op"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(1840,1220)" name="Priority Encoder"/>
-    <comp lib="2" loc="(890,1460)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="3" loc="(1930,1700)" name="Shifter">
       <a name="width" val="16"/>
-      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(210,1810)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
+    <comp lib="0" loc="(1880,540)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk_no_inhibit"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(940,1470)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(2340,1120)" name="OR Gate">
+    <comp lib="1" loc="(420,700)" name="Controlled Buffer">
       <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
+      <a name="width" val="16"/>
     </comp>
-    <comp lib="1" loc="(1430,970)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(180,1150)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="exc_trig_ext"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1900,1420)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(2220,750)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="data_out"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="1" loc="(1880,810)" name="OR Gate">
+    <comp lib="2" loc="(1840,1060)" name="Priority Encoder"/>
+    <comp lib="0" loc="(1740,1040)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="2op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1620,950)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="3"/>
     </comp>
@@ -3973,10 +3592,276 @@ c084088
       <a name="label" val="phase"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2410,1780)" name="Tunnel">
+    <comp lib="4" loc="(180,1500)" name="D Flip-Flop"/>
+    <comp lib="1" loc="(540,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1830,540)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1880,1710)" name="Constant">
+      <a name="width" val="4"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="6" loc="(447,1560)" name="Text">
+      <a name="text" val="1 - waiting"/>
+    </comp>
+    <comp lib="2" loc="(1200,810)" name="Demultiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(610,1700)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="int_en"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2350,1620)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3_ind"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,670)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R4"/>
+    </comp>
+    <comp lib="0" loc="(140,1200)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="IRQ"/>
+    </comp>
+    <comp lib="6" loc="(1789,595)" name="Text">
+      <a name="text" val="CVZN"/>
+    </comp>
+    <comp lib="1" loc="(820,550)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(440,1320)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_trig_div_by_zero"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(880,1180)" name="Tunnel">
+      <a name="label" val="critical_fault"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1830,820)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1910,790)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="0op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,1400)" name="Bit Extender">
+      <a name="in_width" val="6"/>
+    </comp>
+    <comp lib="1" loc="(1990,1490)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(1710,1310)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_abs_nop"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(441,1585)" name="Text">
+      <a name="text" val="3 - fault"/>
+    </comp>
+    <comp lib="0" loc="(1370,1420)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rs1_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1110)" name="Tunnel">
+      <a name="label" val="ps_latch_word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1740,1720)" name="Tunnel">
+      <a name="label" val="imm_extend_negative"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2000,1630)" name="Tunnel">
+      <a name="label" val="imm_shift"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(390,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(140,1090)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="EXC"/>
+    </comp>
+    <comp lib="0" loc="(1160,620)" name="Tunnel">
+      <a name="label" val="imm_asrt1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(340,1720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="CUT"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1400,440)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1250,960)" name="Tunnel">
+      <a name="label" val="imm6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1260,1000)" name="Tunnel">
+      <a name="label" val="mem3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(280,1540)" name="Constant"/>
+    <comp lib="0" loc="(2690,1070)" name="Tunnel">
+      <a name="label" val="ps_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1190,1230)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="ps_flags"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,430)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="SP"/>
+    </comp>
+    <comp lib="0" loc="(670,1500)" name="Bit Extender">
+      <a name="in_width" val="6"/>
+    </comp>
+    <comp lib="1" loc="(840,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(1900,1420)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1990,1450)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1480,560)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="pc_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1370,1400)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_d0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2020,1710)" name="OR Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2120,730)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="sign_extend"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1970,500)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="address"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="2" loc="(680,1200)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(210,550)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R0"/>
+    </comp>
+    <comp lib="1" loc="(720,700)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1160,1540)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1350,1630)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="1" loc="(1580,950)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(2180,1520)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="imm6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(270,1500)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="2" loc="(2520,1780)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1690,860)" name="Tunnel">
+      <a name="label" val="halt"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1360,1630)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1690,430)" name="Tunnel">
+      <a name="label" val="mem"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1660,810)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(170,1770)" name="Counter">
+      <a name="width" val="3"/>
+      <a name="max" val="0x7"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(2160,1450)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="width" val="3"/>
-      <a name="label" val="alu_op_d1"/>
+      <a name="label" val="rd"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(130,580)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R1"/>
+    </comp>
+    <comp lib="2" loc="(600,1250)" name="Priority Encoder"/>
+    <comp lib="0" loc="(250,430)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="sp_value"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1880,970)" name="Tunnel">
@@ -3985,62 +3870,177 @@ c084088
       <a name="label" val="op_type_d3"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(420,700)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
+    <comp lib="2" loc="(2410,1720)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1990,1450)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="1" loc="(690,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2460,1560)" name="Tunnel">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(1580,420)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="arith_carry"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(210,1250)" name="Tunnel">
+    <comp lib="0" loc="(1350,1350)" name="Tunnel">
       <a name="width" val="6"/>
-      <a name="label" val="int_vec"/>
+      <a name="label" val="imm6_d"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2300,1160)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="0"/>
+    <comp lib="1" loc="(700,1720)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1760,1320)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2060,630)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2050,1720)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(130,460)" name="Pin">
       <a name="output" val="true"/>
       <a name="width" val="16"/>
       <a name="label" val="PC"/>
     </comp>
-    <comp lib="0" loc="(450,1710)" name="Tunnel">
-      <a name="label" val="startup"/>
+    <comp lib="0" loc="(210,1130)" name="Tunnel">
+      <a name="width" val="6"/>
+      <a name="label" val="exc_vec"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2320,1100)" name="Constant">
-      <a name="width" val="28"/>
-      <a name="value" val="0x8000000"/>
+    <comp lib="0" loc="(1680,1590)" name="Bit Extender">
+      <a name="in_width" val="9"/>
     </comp>
-    <comp lib="1" loc="(660,1050)" name="Controlled Buffer">
+    <comp lib="1" loc="(810,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="6" loc="(446,1572)" name="Text">
+      <a name="text" val="2 - halted"/>
+    </comp>
+    <comp lib="0" loc="(2190,710)" name="Tunnel">
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1790,620)" name="Probe">
       <a name="facing" val="south"/>
-      <a name="width" val="16"/>
+      <a name="labelfont" val="SansSerif plain 16"/>
     </comp>
-    <comp lib="0" loc="(2140,840)" name="Tunnel">
+    <comp lib="0" loc="(1750,640)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="inc_address"/>
+      <a name="width" val="4"/>
+      <a name="label" val="CVZN"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1010,1500)" name="Constant">
+    <comp lib="0" loc="(120,1530)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="wait"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1250)" name="Tunnel">
+      <a name="label" val="sp_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1010)" name="Tunnel">
+      <a name="label" val="pc_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(2230,1060)" name="ROM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="28"/>
+      <a name="contents">addr/data: 10 28
+4*0 4*c000000 4a00282 5280882 ca00282 d280882 ce00082 e280082
+ca01082 d284082 ca20082 d2c0082 c0c0580 4a00282 8440000 a020000
+8041000 8024000 8040200 8020800 6*0 804a001 15*0 c0c8082
+80c8082 81c8082 c0c8080 80c8080 81c8080 c028082 8028082 8*0
+c0c00ce c0c00ee 80c008e 80c00ae 81c008e 81c00ae c0200ce c0200ee
+802008e 80200ae 8040010 8040030 804a009 804a029 800a008 800a028
+4a01082 4080888 ca00092 ca000b2 a200049 a200069 4a00282 4a00282
+8*0 c0d8082 80d8082 81d8082 c0d8080 80d8080 81d8080 c038082
+8038082 8*0 c080980 804a001 801a000 805a001 8000949 8000969
+8000400 c080580 16*0 c080980 d284082 9*0 8020800 60*0
+4a00282 c084088 4*0 8000949 8000969 120*0 4080888 127*0
+c084088
+</a>
+    </comp>
+    <comp lib="1" loc="(1370,1020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1740,690)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="di"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(150,1790)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,910)" name="Tunnel">
+      <a name="label" val="imm_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1180,900)" name="Demultiplexer">
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(2350,1560)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(3970,2520)" name="Ground"/>
+    <comp lib="0" loc="(1690,1190)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2420,1610)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(260,990)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="rd"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(520,550)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
       <a name="width" val="16"/>
-      <a name="value" val="0x8006"/>
+    </comp>
+    <comp lib="2" loc="(1640,910)" name="Decoder">
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(90,1770)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="CUT"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2010,1110)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+    </comp>
+    <comp lib="0" loc="(2220,1480)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rs0_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(130,1780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(1570,880)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="appear" val="center"/>
     </comp>
   </circuit>
   <circuit name="sp_register">
@@ -4092,14 +4092,44 @@ c084088
     <wire from="(540,540)" to="(550,540)"/>
     <wire from="(570,730)" to="(580,730)"/>
     <wire from="(530,740)" to="(540,740)"/>
-    <comp lib="0" loc="(530,740)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="up"/>
-      <a name="label" val="en"/>
+    <comp lib="0" loc="(800,490)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="Out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(460,700)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="+2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(300,770)" name="Tunnel">
+      <a name="label" val="-2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp loc="(650,500)" name="incdec2"/>
-    <comp lib="0" loc="(300,740)" name="Tunnel">
+    <comp lib="4" loc="(550,500)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(650,520)" name="Tunnel">
+      <a name="facing" val="north"/>
       <a name="label" val="+2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,740)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="+2"/>
+    </comp>
+    <comp lib="1" loc="(500,710)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(460,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="-2"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(520,700)" name="Tunnel">
@@ -4111,6 +4141,11 @@ c084088
       <a name="facing" val="north"/>
       <a name="label" val="-2"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(490,500)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(550,570)" name="Pin">
       <a name="facing" val="west"/>
@@ -4124,40 +4159,28 @@ c084088
       <a name="label" val="count"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(490,500)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(800,490)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="Out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(460,700)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="+2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(330,490)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="In"/>
-    </comp>
-    <comp lib="0" loc="(650,520)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="+2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,740)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="+2"/>
-    </comp>
     <comp lib="0" loc="(580,730)" name="Tunnel">
       <a name="label" val="en"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(510,540)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="en"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(550,540)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(570,730)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(300,740)" name="Tunnel">
+      <a name="label" val="+2"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(600,600)" name="Pin">
@@ -4167,43 +4190,20 @@ c084088
       <a name="label" val="Mon"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="1" loc="(570,730)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(510,540)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(500,710)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(550,500)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(550,540)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(300,770)" name="Tunnel">
-      <a name="label" val="-2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
     <comp lib="2" loc="(770,490)" name="Multiplexer">
       <a name="width" val="16"/>
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(460,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="-2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="0" loc="(530,740)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="up"/>
+      <a name="label" val="en"/>
+    </comp>
+    <comp lib="0" loc="(330,490)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="In"/>
     </comp>
     <comp lib="0" loc="(290,770)" name="Pin">
       <a name="tristate" val="false"/>
@@ -4256,86 +4256,10 @@ c084088
     <wire from="(570,730)" to="(580,730)"/>
     <wire from="(530,740)" to="(540,740)"/>
     <wire from="(510,720)" to="(520,720)"/>
-    <comp lib="0" loc="(300,800)" name="Tunnel">
-      <a name="label" val="asrt_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(470,520)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="count"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(810,490)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="Out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(570,730)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(580,730)" name="Tunnel">
-      <a name="label" val="en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(550,540)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(290,800)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="asrt_inc"/>
-    </comp>
-    <comp loc="(660,500)" name="incdec2"/>
-    <comp lib="0" loc="(520,700)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="count"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(510,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="+2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(300,770)" name="Tunnel">
-      <a name="label" val="+2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(510,540)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(530,740)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="up"/>
-      <a name="label" val="en"/>
-    </comp>
-    <comp lib="0" loc="(330,490)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="In"/>
-    </comp>
     <comp lib="0" loc="(760,520)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="asrt_inc"/>
       <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(490,500)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(780,490)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(610,590)" name="Pin">
       <a name="facing" val="north"/>
@@ -4344,10 +4268,57 @@ c084088
       <a name="label" val="Mon"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(580,730)" name="Tunnel">
+      <a name="label" val="en"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
     <comp lib="0" loc="(290,770)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="pull" val="down"/>
       <a name="label" val="+2"/>
+    </comp>
+    <comp loc="(660,500)" name="incdec2"/>
+    <comp lib="4" loc="(550,500)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(510,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="+2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(780,490)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(470,520)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="count"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(570,730)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(330,490)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="In"/>
+    </comp>
+    <comp lib="2" loc="(490,500)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(300,770)" name="Tunnel">
+      <a name="label" val="+2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(530,740)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="up"/>
+      <a name="label" val="en"/>
     </comp>
     <comp lib="0" loc="(550,570)" name="Pin">
       <a name="facing" val="west"/>
@@ -4356,9 +4327,38 @@ c084088
       <a name="label" val="clk"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(550,500)" name="Register">
+    <comp lib="0" loc="(510,540)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="en"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(300,800)" name="Tunnel">
+      <a name="label" val="asrt_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,800)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="asrt_inc"/>
+    </comp>
+    <comp lib="0" loc="(810,490)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
       <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
+      <a name="label" val="Out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(550,540)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(520,700)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="count"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
   </circuit>
   <circuit name="ps_register">
@@ -4431,6 +4431,132 @@ c084088
     <wire from="(370,540)" to="(370,590)"/>
     <wire from="(300,540)" to="(370,540)"/>
     <wire from="(490,410)" to="(490,530)"/>
+    <comp lib="0" loc="(400,240)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="set_int_flag"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(500,350)" name="Tunnel">
+      <a name="label" val="ei"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(480,530)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(430,550)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(370,590)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ei"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(380,210)" name="Multiplexer">
+      <a name="facing" val="west"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(300,520)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="latch_flags"/>
+    </comp>
+    <comp lib="0" loc="(640,320)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="out_flags"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(300,560)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="di"/>
+    </comp>
+    <comp lib="0" loc="(350,590)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="di"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(510,50)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="flags"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(300,540)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="ei"/>
+    </comp>
+    <comp lib="0" loc="(300,450)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(500,270)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="15"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+      <a name="bit15" val="none"/>
+    </comp>
+    <comp lib="0" loc="(360,320)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="word"/>
+    </comp>
+    <comp lib="0" loc="(580,400)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(620,320)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(460,110)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(500,50)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="4" loc="(530,400)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="2" loc="(460,400)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(450,560)" name="Tunnel">
+      <a name="label" val="set_int_flag"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(300,500)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="latch_word"/>
+    </comp>
+    <comp lib="0" loc="(460,280)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
     <comp lib="0" loc="(500,130)" name="Splitter">
       <a name="facing" val="west"/>
       <a name="fanout" val="12"/>
@@ -4453,135 +4579,9 @@ c084088
       <a name="bit14" val="10"/>
       <a name="bit15" val="11"/>
     </comp>
-    <comp lib="0" loc="(300,500)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="latch_word"/>
-    </comp>
-    <comp lib="0" loc="(350,590)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="di"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(640,320)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="4"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="out_flags"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(430,550)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(300,450)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="0" loc="(370,590)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ei"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(380,210)" name="Multiplexer">
-      <a name="facing" val="west"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(620,320)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="4"/>
-    </comp>
-    <comp lib="0" loc="(360,320)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="word"/>
-    </comp>
     <comp lib="1" loc="(430,510)" name="OR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(300,540)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="ei"/>
-    </comp>
-    <comp lib="0" loc="(500,270)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="15"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-      <a name="bit15" val="none"/>
-    </comp>
-    <comp lib="0" loc="(500,350)" name="Tunnel">
-      <a name="label" val="ei"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(500,50)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(300,560)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="di"/>
-    </comp>
-    <comp lib="0" loc="(460,280)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(460,110)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(450,560)" name="Tunnel">
-      <a name="label" val="set_int_flag"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(300,520)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="latch_flags"/>
-    </comp>
-    <comp lib="0" loc="(510,50)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="width" val="4"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="flags"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(400,240)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="set_int_flag"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(580,400)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(460,400)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(480,530)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(530,400)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
     </comp>
   </circuit>
   <circuit name="address_adder">
@@ -4609,6 +4609,22 @@ c084088
     <wire from="(480,440)" to="(480,480)"/>
     <wire from="(480,500)" to="(520,500)"/>
     <wire from="(480,500)" to="(480,540)"/>
+    <comp lib="3" loc="(560,490)" name="Adder">
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(670,490)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="17"/>
+      <a name="label" val="Out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(630,490)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
     <comp lib="0" loc="(420,540)" name="Pin">
       <a name="width" val="16"/>
       <a name="tristate" val="false"/>
@@ -4619,22 +4635,6 @@ c084088
       <a name="fanout" val="16"/>
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(630,490)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="3" loc="(560,490)" name="Adder">
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(670,490)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="17"/>
-      <a name="label" val="Out"/>
-      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(420,440)" name="Pin">
       <a name="width" val="16"/>
@@ -4659,22 +4659,16 @@ c084088
     <wire from="(630,490)" to="(670,490)"/>
     <wire from="(500,490)" to="(590,490)"/>
     <wire from="(500,570)" to="(610,570)"/>
-    <comp lib="0" loc="(590,490)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(630,490)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
     <comp lib="0" loc="(500,490)" name="Pin">
       <a name="width" val="16"/>
       <a name="tristate" val="false"/>
       <a name="pull" val="down"/>
       <a name="label" val="A"/>
+    </comp>
+    <comp lib="0" loc="(500,570)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="B"/>
     </comp>
     <comp lib="0" loc="(670,490)" name="Pin">
       <a name="facing" val="west"/>
@@ -4683,10 +4677,16 @@ c084088
       <a name="label" val="Out"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(500,570)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="B"/>
+    <comp lib="0" loc="(630,490)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(590,490)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
     </comp>
   </circuit>
   <circuit name="incdec16">
@@ -4710,19 +4710,9 @@ c084088
     <wire from="(360,390)" to="(540,390)"/>
     <wire from="(510,410)" to="(510,420)"/>
     <wire from="(580,400)" to="(670,400)"/>
-    <comp lib="2" loc="(480,420)" name="Multiplexer">
+    <comp lib="0" loc="(440,410)" name="Constant">
       <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(460,460)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="up"/>
-      <a name="label" val="inc/dec'"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(440,430)" name="Constant">
-      <a name="width" val="16"/>
+      <a name="value" val="0xffff"/>
     </comp>
     <comp lib="0" loc="(670,400)" name="Pin">
       <a name="facing" val="west"/>
@@ -4731,17 +4721,27 @@ c084088
       <a name="label" val="out"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="3" loc="(580,400)" name="Adder">
+    <comp lib="2" loc="(480,420)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(440,430)" name="Constant">
       <a name="width" val="16"/>
     </comp>
-    <comp lib="0" loc="(440,410)" name="Constant">
+    <comp lib="3" loc="(580,400)" name="Adder">
       <a name="width" val="16"/>
-      <a name="value" val="0xffff"/>
     </comp>
     <comp lib="0" loc="(360,390)" name="Pin">
       <a name="width" val="16"/>
       <a name="tristate" val="false"/>
       <a name="label" val="in"/>
+    </comp>
+    <comp lib="0" loc="(460,460)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="up"/>
+      <a name="label" val="inc/dec'"/>
+      <a name="labelloc" val="south"/>
     </comp>
   </circuit>
   <circuit name="incdec2">
@@ -4765,6 +4765,10 @@ c084088
     <wire from="(360,390)" to="(540,390)"/>
     <wire from="(510,410)" to="(510,420)"/>
     <wire from="(580,400)" to="(670,400)"/>
+    <comp lib="0" loc="(440,410)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0xfffe"/>
+    </comp>
     <comp lib="2" loc="(480,420)" name="Multiplexer">
       <a name="width" val="16"/>
       <a name="enable" val="false"/>
@@ -4776,21 +4780,10 @@ c084088
       <a name="label" val="out"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="3" loc="(580,400)" name="Adder">
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(440,410)" name="Constant">
-      <a name="width" val="16"/>
-      <a name="value" val="0xfffe"/>
-    </comp>
     <comp lib="0" loc="(360,390)" name="Pin">
       <a name="width" val="16"/>
       <a name="tristate" val="false"/>
       <a name="label" val="in"/>
-    </comp>
-    <comp lib="0" loc="(440,430)" name="Constant">
-      <a name="width" val="16"/>
-      <a name="value" val="0x2"/>
     </comp>
     <comp lib="0" loc="(460,460)" name="Pin">
       <a name="facing" val="north"/>
@@ -4798,6 +4791,13 @@ c084088
       <a name="pull" val="up"/>
       <a name="label" val="inc/dec'"/>
       <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(440,430)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="3" loc="(580,400)" name="Adder">
+      <a name="width" val="16"/>
     </comp>
   </circuit>
   <circuit name="bus_control">
@@ -4895,10 +4895,53 @@ c084088
     <wire from="(580,470)" to="(590,470)"/>
     <wire from="(600,490)" to="(610,490)"/>
     <wire from="(310,730)" to="(380,730)"/>
-    <comp lib="2" loc="(620,460)" name="Multiplexer">
+    <comp lib="0" loc="(330,430)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="from_bus"/>
+    </comp>
+    <comp lib="0" loc="(610,490)" name="Tunnel">
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(200,120)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="sign_extend"/>
+    </comp>
+    <comp loc="(560,470)" name="bytes_swap"/>
+    <comp lib="1" loc="(600,180)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp loc="(590,670)" name="make_byte"/>
+    <comp lib="2" loc="(700,700)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
       <a name="width" val="16"/>
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(650,410)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,180)" name="Tunnel">
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(590,690)" name="2s_compliment"/>
+    <comp lib="2" loc="(650,680)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(710,700)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="to_bus"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(420,840)" name="Tunnel">
       <a name="facing" val="east"/>
@@ -4908,6 +4951,128 @@ c084088
     <comp lib="0" loc="(210,220)" name="Tunnel">
       <a name="label" val="clk_no_inhibit"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(620,180)" name="Tunnel">
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(580,410)" name="make_byte"/>
+    <comp lib="2" loc="(620,460)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(640,750)" name="Tunnel">
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(470,830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(560,170)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="odd"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(760,260)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(680,440)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="data_out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="2" loc="(670,440)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(680,670)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(560,780)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(210,120)" name="Tunnel">
+      <a name="label" val="sign_extend"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(630,650)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="sign_extend"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(200,150)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="odd_address"/>
+    </comp>
+    <comp lib="4" loc="(540,780)" name="Register">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(470,780)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="8"/>
+    </comp>
+    <comp lib="0" loc="(760,240)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(310,730)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="data_in"/>
+    </comp>
+    <comp lib="0" loc="(210,150)" name="Tunnel">
+      <a name="label" val="odd"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,150)" name="Tunnel">
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(620,120)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(560,190)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(200,220)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk_no_inhibit"/>
+    </comp>
+    <comp lib="4" loc="(670,120)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(560,860)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(200,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="word"/>
+    </comp>
+    <comp lib="0" loc="(770,120)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="inc_address"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="2" loc="(650,720)" name="Multiplexer">
       <a name="width" val="16"/>
@@ -4920,81 +5085,9 @@ c084088
       <a name="label" val="clk_inhibit"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(670,120)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="1" loc="(600,180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(330,430)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="from_bus"/>
-    </comp>
-    <comp lib="0" loc="(640,750)" name="Tunnel">
-      <a name="label" val="phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(540,780)" name="Register">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(560,780)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(200,120)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="sign_extend"/>
-    </comp>
-    <comp lib="0" loc="(610,490)" name="Tunnel">
-      <a name="label" val="phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,180)" name="Tunnel">
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(680,440)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="data_out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(200,220)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk_no_inhibit"/>
-    </comp>
-    <comp lib="0" loc="(470,780)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="8"/>
-    </comp>
-    <comp lib="0" loc="(620,180)" name="Tunnel">
+    <comp lib="0" loc="(420,820)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(710,700)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="to_bus"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(650,410)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(560,190)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(560,170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="odd"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(600,820)" name="Splitter">
@@ -5003,104 +5096,11 @@ c084088
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(760,240)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(590,670)" name="make_byte"/>
-    <comp loc="(560,470)" name="bytes_swap"/>
-    <comp loc="(590,690)" name="2s_compliment"/>
-    <comp lib="0" loc="(210,120)" name="Tunnel">
-      <a name="label" val="sign_extend"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(420,820)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(470,830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(670,440)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(760,260)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(200,150)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="odd_address"/>
-    </comp>
-    <comp lib="0" loc="(630,650)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="sign_extend"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(680,670)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
     <comp lib="0" loc="(770,260)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="phase"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(700,700)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(200,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="word"/>
-    </comp>
-    <comp lib="0" loc="(310,730)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="data_in"/>
-    </comp>
-    <comp loc="(580,410)" name="make_byte"/>
-    <comp lib="0" loc="(560,860)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(620,120)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,150)" name="Tunnel">
-      <a name="label" val="odd"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(770,120)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="inc_address"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(720,150)" name="Tunnel">
-      <a name="label" val="phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(650,680)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
     </comp>
   </circuit>
   <circuit name="alu">
@@ -5363,35 +5363,18 @@ c084088
     <wire from="(680,410)" to="(760,410)"/>
     <wire from="(810,480)" to="(820,480)"/>
     <wire from="(560,710)" to="(570,710)"/>
-    <comp lib="2" loc="(1160,1050)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1360,810)" name="Tunnel">
-      <a name="label" val="N"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(580,570)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="neg"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(610,460)" name="XOR Gate">
+    <comp lib="1" loc="(610,420)" name="OR Gate">
       <a name="width" val="16"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(1310,80)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="C"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="0" loc="(740,500)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(290,610)" name="Tunnel">
-      <a name="label" val="scl"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(810,100)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="adc"/>
+    <comp lib="0" loc="(980,90)" name="Tunnel">
+      <a name="label" val="sub"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="2" loc="(600,600)" name="Multiplexer">
@@ -5399,351 +5382,18 @@ c084088
       <a name="width" val="16"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1010,800)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="2" loc="(1050,970)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(470,470)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="B"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1160,870)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(240,260)" name="Tunnel">
-      <a name="label" val="3op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,100)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="V"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(500,70)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="A"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(600,640)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(600,970)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(620,860)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(570,830)" name="make_byte"/>
-    <comp lib="1" loc="(580,670)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1310,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="N"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(560,610)" name="NOT Gate">
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1020,710)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="2op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1130,760)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(190,280)" name="Pin">
-      <a name="width" val="3"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="op_type"/>
-    </comp>
-    <comp lib="0" loc="(1120,1060)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(500,130)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="B"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(200,140)" name="Tunnel">
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,550)" name="Tunnel">
-      <a name="label" val="neg"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(170,660)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="2op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(810,70)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,470)" name="Tunnel">
-      <a name="label" val="adc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(490,130)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="B"/>
-    </comp>
-    <comp lib="0" loc="(290,760)" name="Tunnel">
-      <a name="label" val="shr"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(980,90)" name="Tunnel">
-      <a name="label" val="sub"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,510)" name="Tunnel">
-      <a name="label" val="sbc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(570,800)" name="2s_compliment"/>
-    <comp lib="0" loc="(190,140)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="Cin"/>
-    </comp>
-    <comp lib="2" loc="(190,650)" name="Decoder">
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(1170,1050)" name="Tunnel">
-      <a name="label" val="V"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(940,70)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp loc="(1330,780)" name="zero16"/>
-    <comp lib="0" loc="(170,480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="3op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(640,590)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="adder_carry"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1140,1080)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,430)" name="Tunnel">
-      <a name="label" val="bic"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
     <comp lib="0" loc="(1240,690)" name="Probe">
       <a name="facing" val="south"/>
       <a name="radix" val="16"/>
     </comp>
-    <comp loc="(640,620)" name="adder16">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(810,40)" name="Tunnel">
+    <comp lib="0" loc="(470,450)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="sbc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,590)" name="Tunnel">
-      <a name="label" val="sxt"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(190,170)" name="Pin">
-      <a name="width" val="3"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="func"/>
-    </comp>
-    <comp lib="0" loc="(240,300)" name="Tunnel">
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,140)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="N"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(170,850)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(580,770)" name="NOT Gate">
       <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(660,840)" name="Splitter">
-      <a name="facing" val="west"/>
-    </comp>
-    <comp lib="1" loc="(890,50)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(800,430)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(980,70)" name="Tunnel">
-      <a name="label" val="neg"/>
+      <a name="label" val="A"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(610,420)" name="OR Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(680,790)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(170,870)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(610,500)" name="AND Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(190,470)" name="Decoder">
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(600,1030)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(740,500)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(290,800)" name="Tunnel">
-      <a name="label" val="rol"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1170,870)" name="Tunnel">
-      <a name="label" val="C"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,80)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="C"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(170,680)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,410)" name="Tunnel">
-      <a name="label" val="xor"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,100)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="V"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(960,160)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="adder_carry"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,390)" name="Tunnel">
-      <a name="label" val="or"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,820)" name="Tunnel">
-      <a name="label" val="ror"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(610,380)" name="AND Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1280,730)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="S"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1030,820)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="2op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(850,130)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(290,840)" name="Tunnel">
-      <a name="label" val="rcl"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1030,1000)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="2op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(600,710)" name="Tunnel">
-      <a name="label" val="sbc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,1010)" name="Pin">
-      <a name="width" val="3"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="shift_count"/>
-    </comp>
-    <comp lib="0" loc="(620,860)" name="Splitter">
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-      <a name="bit2" val="none"/>
-    </comp>
-    <comp lib="0" loc="(290,370)" name="Tunnel">
-      <a name="label" val="and"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,570)" name="Tunnel">
-      <a name="label" val="not"/>
+    <comp lib="0" loc="(290,860)" name="Tunnel">
+      <a name="label" val="rcr"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(740,500)" name="Tunnel">
@@ -5752,10 +5402,220 @@ c084088
       <a name="label" val="func"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(2850,390)" name="NOT Gate"/>
     <comp lib="0" loc="(1360,780)" name="Tunnel">
       <a name="label" val="Z"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(640,590)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="adder_carry"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1160,1050)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(290,470)" name="Tunnel">
+      <a name="label" val="adc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1030,1000)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="2op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(850,130)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(290,760)" name="Tunnel">
+      <a name="label" val="shr"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1120,1060)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(1310,120)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="Z"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(170,660)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="2op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,840)" name="Tunnel">
+      <a name="label" val="rcl"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(190,170)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="func"/>
+    </comp>
+    <comp lib="2" loc="(680,790)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(170,680)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1220,1710)" name="NOT Gate"/>
+    <comp lib="2" loc="(190,650)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(490,130)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="B"/>
+    </comp>
+    <comp lib="0" loc="(600,970)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,590)" name="Tunnel">
+      <a name="label" val="sxt"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1310,100)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="V"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(800,430)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(290,570)" name="Tunnel">
+      <a name="label" val="not"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(240,280)" name="Tunnel">
+      <a name="label" val="2op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(810,70)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(200,170)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1310,100)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="V"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(580,670)" name="OR Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(600,710)" name="Tunnel">
+      <a name="label" val="sbc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(240,300)" name="Tunnel">
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(170,850)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(660,840)" name="Splitter">
+      <a name="facing" val="west"/>
+    </comp>
+    <comp lib="0" loc="(500,70)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="A"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(940,70)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1020,710)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="2op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1170,870)" name="Tunnel">
+      <a name="label" val="C"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,610)" name="Tunnel">
+      <a name="label" val="scl"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(490,70)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="A"/>
+    </comp>
+    <comp lib="0" loc="(290,740)" name="Tunnel">
+      <a name="label" val="shl"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(170,500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(240,260)" name="Tunnel">
+      <a name="label" val="3op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(470,470)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="B"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,390)" name="Tunnel">
+      <a name="label" val="or"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(570,510)" name="NOT Gate">
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1310,80)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="C"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(210,1010)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="shift_count"/>
+    </comp>
+    <comp lib="0" loc="(560,710)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="sub"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(610,500)" name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(1340,810)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -5778,122 +5638,262 @@ c084088
       <a name="bit14" val="none"/>
       <a name="bit15" val="0"/>
     </comp>
-    <comp lib="0" loc="(1310,120)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Z"/>
+    <comp lib="0" loc="(1140,1080)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="shifts"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(200,170)" name="Tunnel">
+    <comp lib="0" loc="(290,430)" name="Tunnel">
+      <a name="label" val="bic"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(610,380)" name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(960,160)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="adder_carry"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(620,860)" name="Splitter">
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+      <a name="bit2" val="none"/>
+    </comp>
+    <comp lib="2" loc="(850,470)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1170,1050)" name="Tunnel">
+      <a name="label" val="V"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(810,40)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="sbc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(890,50)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(980,70)" name="Tunnel">
+      <a name="label" val="neg"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(610,460)" name="XOR Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(290,780)" name="Tunnel">
+      <a name="label" val="shra"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1130,760)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2850,390)" name="NOT Gate"/>
+    <comp lib="0" loc="(580,570)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="neg"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(620,860)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="width" val="3"/>
       <a name="label" val="func"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
+    <comp loc="(600,1000)" name="barrel_shifter">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="2" loc="(1160,870)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(290,800)" name="Tunnel">
+      <a name="label" val="rol"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,510)" name="Tunnel">
+      <a name="label" val="sbc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(640,620)" name="adder16">
+      <a name="facing" val="north"/>
+    </comp>
     <comp lib="2" loc="(1050,790)" name="Multiplexer">
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(580,770)" name="NOT Gate">
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(890,90)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1310,140)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="N"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(1140,900)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="shifts"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(200,280)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1010,980)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="1" loc="(960,150)" name="OR Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(560,710)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="sub"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(470,450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="A"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1150,730)" name="Multiplexer">
+    <comp loc="(570,800)" name="2s_compliment"/>
+    <comp lib="2" loc="(1040,690)" name="Multiplexer">
       <a name="width" val="16"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1310,120)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Z"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(490,70)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="A"/>
-    </comp>
-    <comp lib="0" loc="(290,740)" name="Tunnel">
-      <a name="label" val="shl"/>
+    <comp lib="0" loc="(810,100)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="adc"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(290,490)" name="Tunnel">
       <a name="label" val="sub"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(570,510)" name="NOT Gate">
+    <comp lib="0" loc="(1010,800)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp loc="(570,830)" name="make_byte"/>
+    <comp lib="0" loc="(1280,730)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="S"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(290,370)" name="Tunnel">
+      <a name="label" val="and"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(190,280)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="op_type"/>
+    </comp>
+    <comp lib="0" loc="(290,820)" name="Tunnel">
+      <a name="label" val="ror"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,410)" name="Tunnel">
+      <a name="label" val="xor"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1030,820)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="2op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(560,650)" name="NOT Gate">
       <a name="width" val="16"/>
     </comp>
-    <comp lib="0" loc="(780,480)" name="Splitter">
-      <a name="facing" val="west"/>
+    <comp lib="0" loc="(290,550)" name="Tunnel">
+      <a name="label" val="neg"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1220,1710)" name="NOT Gate"/>
-    <comp lib="1" loc="(890,90)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(1310,80)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="C"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(170,480)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="3op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(290,450)" name="Tunnel">
       <a name="label" val="add"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(170,500)" name="Tunnel">
+    <comp lib="0" loc="(500,130)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="B"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(190,470)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(1310,140)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
+      <a name="label" val="N"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="2" loc="(190,840)" name="Decoder">
       <a name="select" val="3"/>
       <a name="disabled" val="0"/>
     </comp>
-    <comp lib="0" loc="(290,860)" name="Tunnel">
-      <a name="label" val="rcr"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="0" loc="(200,280)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(290,780)" name="Tunnel">
-      <a name="label" val="shra"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="0" loc="(780,480)" name="Splitter">
+      <a name="facing" val="west"/>
     </comp>
-    <comp lib="0" loc="(240,280)" name="Tunnel">
-      <a name="label" val="2op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1040,690)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(850,470)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp loc="(600,1000)" name="barrel_shifter">
+    <comp lib="0" loc="(600,1030)" name="Tunnel">
       <a name="facing" val="north"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(560,650)" name="NOT Gate">
+    <comp lib="0" loc="(1360,810)" name="Tunnel">
+      <a name="label" val="N"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1150,730)" name="Multiplexer">
       <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(190,140)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="Cin"/>
+    </comp>
+    <comp lib="0" loc="(1010,980)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="2" loc="(1050,970)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(600,640)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp loc="(1330,780)" name="zero16"/>
+    <comp lib="1" loc="(960,150)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(170,870)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(560,610)" name="NOT Gate">
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(200,140)" name="Tunnel">
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1310,120)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Z"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
   </circuit>
   <circuit name="multiplier">
@@ -6117,6 +6117,69 @@ c084088
     <wire from="(740,770)" to="(740,830)"/>
     <wire from="(890,580)" to="(890,760)"/>
     <wire from="(850,560)" to="(850,610)"/>
+    <comp lib="0" loc="(1180,600)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="SLow"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(210,380)" name="Splitter">
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(170,790)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="reset"/>
+    </comp>
+    <comp lib="0" loc="(550,610)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="reset"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(560,530)" name="D Flip-Flop"/>
+    <comp lib="2" loc="(830,520)" name="Demultiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="8"/>
+      <a name="tristate" val="true"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1100,830)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(230,690)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="count"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1100,730)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="2" loc="(420,450)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="8"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(430,80)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1100,650)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(760,470)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
     <comp lib="0" loc="(1180,780)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -6124,20 +6187,85 @@ c084088
       <a name="label" val="SHigh"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="4" loc="(670,760)" name="Register"/>
+    <comp lib="0" loc="(230,440)" name="Bit Extender">
+      <a name="in_width" val="1"/>
+      <a name="out_width" val="8"/>
+    </comp>
+    <comp lib="0" loc="(650,440)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="2" loc="(720,270)" name="Multiplexer">
+      <a name="width" val="8"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(820,720)" name="Register"/>
+    <comp lib="0" loc="(450,450)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(720,430)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="3" loc="(780,300)" name="Multiplier"/>
+    <comp lib="0" loc="(1140,600)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1100,910)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
     <comp lib="0" loc="(450,530)" name="Splitter">
       <a name="fanout" val="8"/>
       <a name="incoming" val="8"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(1140,780)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-    </comp>
-    <comp lib="3" loc="(560,480)" name="Adder">
+    <comp lib="0" loc="(210,200)" name="Pin">
       <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="A"/>
     </comp>
-    <comp lib="0" loc="(430,80)" name="Splitter">
+    <comp lib="0" loc="(170,750)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(210,240)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="B"/>
+    </comp>
+    <comp lib="4" loc="(710,720)" name="Register"/>
+    <comp lib="2" loc="(860,430)" name="Demultiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="8"/>
+      <a name="tristate" val="true"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(570,80)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(170,820)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="count"/>
+    </comp>
+    <comp lib="0" loc="(280,710)" name="Tunnel">
+      <a name="label" val="reset"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(780,760)" name="Register"/>
+    <comp lib="0" loc="(570,160)" name="Splitter">
       <a name="facing" val="west"/>
       <a name="fanout" val="8"/>
       <a name="incoming" val="8"/>
@@ -6149,128 +6277,9 @@ c084088
       <a name="incoming" val="8"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(570,160)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="2" loc="(720,270)" name="Multiplexer">
-      <a name="width" val="8"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(170,750)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="3" loc="(780,300)" name="Multiplier"/>
-    <comp lib="0" loc="(280,710)" name="Tunnel">
-      <a name="label" val="reset"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(720,430)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(170,790)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="reset"/>
-    </comp>
-    <comp lib="2" loc="(420,520)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="8"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="4" loc="(670,760)" name="Register"/>
-    <comp lib="0" loc="(760,390)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(210,380)" name="Splitter">
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(530,200)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-    </comp>
-    <comp lib="0" loc="(180,820)" name="Tunnel">
-      <a name="label" val="count"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(560,530)" name="D Flip-Flop"/>
-    <comp lib="2" loc="(860,430)" name="Demultiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="8"/>
-      <a name="tristate" val="true"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1140,600)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-    </comp>
-    <comp lib="0" loc="(620,860)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="reset"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(820,720)" name="Register"/>
     <comp lib="0" loc="(390,200)" name="Splitter">
       <a name="fanout" val="16"/>
       <a name="incoming" val="16"/>
-    </comp>
-    <comp lib="0" loc="(230,690)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="count"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1100,650)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(180,790)" name="Tunnel">
-      <a name="label" val="reset"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,240)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="B"/>
-    </comp>
-    <comp lib="2" loc="(420,450)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="8"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(570,80)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="2" loc="(690,320)" name="Multiplexer">
-      <a name="width" val="8"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="4" loc="(780,760)" name="Register"/>
-    <comp lib="0" loc="(170,820)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="count"/>
-    </comp>
-    <comp lib="0" loc="(550,610)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="reset"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(830,520)" name="Demultiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="8"/>
-      <a name="tristate" val="true"/>
-      <a name="enable" val="false"/>
     </comp>
     <comp lib="4" loc="(270,680)" name="Counter">
       <a name="width" val="2"/>
@@ -6283,45 +6292,51 @@ c084088
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(650,440)" name="Splitter">
+    <comp lib="0" loc="(180,820)" name="Tunnel">
+      <a name="label" val="count"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(420,520)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="8"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(760,390)" name="Splitter">
       <a name="facing" val="west"/>
       <a name="fanout" val="8"/>
       <a name="incoming" val="8"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="4" loc="(710,720)" name="Register"/>
+    <comp lib="0" loc="(620,860)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="reset"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(530,200)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1140,780)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+    </comp>
+    <comp lib="0" loc="(610,480)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(180,790)" name="Tunnel">
+      <a name="label" val="reset"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="3" loc="(560,480)" name="Adder">
+      <a name="width" val="16"/>
+    </comp>
     <comp lib="0" loc="(620,830)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="count"/>
       <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1180,600)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="SLow"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1100,730)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(760,470)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1100,830)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(450,450)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(430,160)" name="Splitter">
       <a name="facing" val="west"/>
@@ -6329,24 +6344,9 @@ c084088
       <a name="incoming" val="8"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(210,200)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="A"/>
-    </comp>
-    <comp lib="0" loc="(230,440)" name="Bit Extender">
-      <a name="in_width" val="1"/>
-      <a name="out_width" val="8"/>
-    </comp>
-    <comp lib="0" loc="(610,480)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1100,910)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
+    <comp lib="2" loc="(690,320)" name="Multiplexer">
+      <a name="width" val="8"/>
+      <a name="enable" val="false"/>
     </comp>
   </circuit>
   <circuit name="barrel_shifter">
@@ -6471,28 +6471,11 @@ c084088
     <wire from="(910,600)" to="(1040,600)"/>
     <wire from="(150,180)" to="(160,180)"/>
     <wire from="(610,1140)" to="(610,1330)"/>
-    <comp lib="0" loc="(150,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="cin"/>
-    </comp>
     <comp lib="0" loc="(580,1710)" name="Splitter">
       <a name="facing" val="west"/>
       <a name="fanout" val="17"/>
       <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1070,440)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="3" loc="(310,300)" name="Adder">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="6" loc="(658,465)" name="Text">
-      <a name="text" val="shl"/>
-      <a name="font" val="SansSerif bold 14"/>
     </comp>
     <comp lib="0" loc="(760,930)" name="Splitter">
       <a name="facing" val="west"/>
@@ -6500,34 +6483,18 @@ c084088
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="6" loc="(659,1689)" name="Text">
-      <a name="text" val="rcr"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="0" loc="(620,1330)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="5"/>
-      <a name="appear" val="right"/>
-      <a name="bit4" val="none"/>
-    </comp>
-    <comp lib="0" loc="(540,920)" name="Splitter">
+    <comp lib="0" loc="(760,1730)" name="Splitter">
+      <a name="facing" val="west"/>
       <a name="fanout" val="16"/>
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="6" loc="(660,1477)" name="Text">
-      <a name="text" val="rcl"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="0" loc="(580,490)" name="Splitter">
+    <comp lib="0" loc="(1110,390)" name="Pin">
       <a name="facing" val="west"/>
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="3" loc="(680,920)" name="Shifter">
-      <a name="width" val="17"/>
-      <a name="shift" val="ar"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="Out"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(150,230)" name="Pin">
       <a name="width" val="3"/>
@@ -6535,14 +6502,77 @@ c084088
       <a name="pull" val="down"/>
       <a name="label" val="shift_type"/>
     </comp>
-    <comp lib="0" loc="(720,1720)" name="Splitter">
+    <comp lib="3" loc="(680,1510)" name="Shifter">
+      <a name="width" val="17"/>
+      <a name="shift" val="rl"/>
+    </comp>
+    <comp lib="0" loc="(540,490)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(160,120)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(620,1330)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="5"/>
+      <a name="appear" val="right"/>
+      <a name="bit4" val="none"/>
+    </comp>
+    <comp lib="0" loc="(580,490)" name="Splitter">
+      <a name="facing" val="west"/>
       <a name="fanout" val="17"/>
       <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="3" loc="(700,1130)" name="Shifter">
-      <a name="width" val="16"/>
-      <a name="shift" val="rl"/>
+    <comp lib="0" loc="(620,1140)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="5"/>
+      <a name="appear" val="right"/>
+      <a name="bit4" val="none"/>
+    </comp>
+    <comp lib="2" loc="(1080,620)" name="Multiplexer">
+      <a name="select" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="6" loc="(660,1477)" name="Text">
+      <a name="text" val="rcl"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="0" loc="(580,700)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(560,1630)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(760,1350)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="0"/>
     </comp>
     <comp lib="0" loc="(760,1160)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -6569,31 +6599,97 @@ c084088
       <a name="label" val="type"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(720,1510)" name="Splitter">
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
+    <comp lib="0" loc="(150,290)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="distance"/>
+    </comp>
+    <comp lib="0" loc="(760,1510)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="3" loc="(680,500)" name="Shifter">
-      <a name="width" val="17"/>
+    <comp lib="0" loc="(660,1330)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
     </comp>
-    <comp lib="0" loc="(230,340)" name="Constant">
+    <comp lib="0" loc="(760,500)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="3" loc="(310,300)" name="Adder">
       <a name="width" val="5"/>
     </comp>
     <comp lib="3" loc="(700,1320)" name="Shifter">
       <a name="width" val="16"/>
       <a name="shift" val="rr"/>
     </comp>
-    <comp lib="3" loc="(680,1510)" name="Shifter">
-      <a name="width" val="17"/>
-      <a name="shift" val="rl"/>
+    <comp lib="0" loc="(230,340)" name="Constant">
+      <a name="width" val="5"/>
     </comp>
-    <comp lib="2" loc="(1080,620)" name="Multiplexer">
+    <comp lib="0" loc="(560,1580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(580,910)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="2" loc="(1080,390)" name="Multiplexer">
       <a name="select" val="3"/>
+      <a name="width" val="16"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(580,700)" name="Splitter">
+    <comp lib="6" loc="(658,465)" name="Text">
+      <a name="text" val="shl"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="3" loc="(680,920)" name="Shifter">
+      <a name="width" val="17"/>
+      <a name="shift" val="ar"/>
+    </comp>
+    <comp lib="3" loc="(680,1720)" name="Shifter">
+      <a name="width" val="17"/>
+      <a name="shift" val="rr"/>
+    </comp>
+    <comp lib="0" loc="(540,1720)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(580,1500)" name="Splitter">
       <a name="facing" val="west"/>
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(720,500)" name="Splitter">
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(160,180)" name="Tunnel">
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(220,290)" name="Bit Extender">
+      <a name="in_width" val="3"/>
+      <a name="out_width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(150,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="cin"/>
+    </comp>
+    <comp lib="0" loc="(720,710)" name="Splitter">
       <a name="fanout" val="17"/>
       <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
@@ -6603,166 +6699,36 @@ c084088
       <a name="label" val="type"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(540,1720)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1110,390)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="Out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="3" loc="(680,710)" name="Shifter">
-      <a name="width" val="17"/>
-      <a name="shift" val="lr"/>
-    </comp>
-    <comp lib="0" loc="(150,290)" name="Pin">
+    <comp lib="0" loc="(1070,440)" name="Tunnel">
       <a name="width" val="3"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="distance"/>
-    </comp>
-    <comp lib="0" loc="(560,1580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="cin"/>
+      <a name="label" val="type"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(580,1500)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(660,1330)" name="Splitter">
+    <comp lib="0" loc="(660,1140)" name="Splitter">
       <a name="facing" val="west"/>
       <a name="fanout" val="4"/>
       <a name="incoming" val="4"/>
-    </comp>
-    <comp lib="0" loc="(560,1630)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(659,890)" name="Text">
-      <a name="text" val="shra"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="0" loc="(760,1730)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="6" loc="(659,680)" name="Text">
-      <a name="text" val="shr"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="3" loc="(680,1720)" name="Shifter">
-      <a name="width" val="17"/>
-      <a name="shift" val="rr"/>
-    </comp>
-    <comp lib="0" loc="(540,490)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(720,500)" name="Splitter">
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(220,290)" name="Bit Extender">
-      <a name="in_width" val="3"/>
-      <a name="out_width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(1110,620)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="cout"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(760,1510)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(620,1140)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="5"/>
-      <a name="appear" val="right"/>
-      <a name="bit4" val="none"/>
-    </comp>
-    <comp lib="0" loc="(310,440)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(150,120)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="In"/>
-    </comp>
-    <comp lib="2" loc="(1080,390)" name="Multiplexer">
-      <a name="select" val="3"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(160,120)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(720,920)" name="Splitter">
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(580,910)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(760,1350)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="0"/>
-    </comp>
-    <comp lib="6" loc="(682,1100)" name="Text">
-      <a name="text" val="rol"/>
-      <a name="font" val="SansSerif bold 14"/>
     </comp>
     <comp lib="0" loc="(540,710)" name="Splitter">
       <a name="fanout" val="16"/>
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(760,500)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
+    <comp lib="6" loc="(659,890)" name="Text">
+      <a name="text" val="shra"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="6" loc="(659,1689)" name="Text">
+      <a name="text" val="rcr"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="6" loc="(659,680)" name="Text">
+      <a name="text" val="shr"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="0" loc="(720,1720)" name="Splitter">
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(540,1500)" name="Splitter">
@@ -6770,28 +6736,62 @@ c084088
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(720,710)" name="Splitter">
+    <comp lib="0" loc="(1110,620)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="cout"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="3" loc="(680,500)" name="Shifter">
+      <a name="width" val="17"/>
+    </comp>
+    <comp lib="3" loc="(680,710)" name="Shifter">
+      <a name="width" val="17"/>
+      <a name="shift" val="lr"/>
+    </comp>
+    <comp lib="0" loc="(540,920)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="3" loc="(700,1130)" name="Shifter">
+      <a name="width" val="16"/>
+      <a name="shift" val="rl"/>
+    </comp>
+    <comp lib="0" loc="(720,1510)" name="Splitter">
       <a name="fanout" val="17"/>
       <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(660,1140)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-    </comp>
-    <comp lib="0" loc="(160,180)" name="Tunnel">
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(681,1292)" name="Text">
-      <a name="text" val="ror"/>
+    <comp lib="6" loc="(682,1100)" name="Text">
+      <a name="text" val="rol"/>
       <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="0" loc="(310,440)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(760,720)" name="Splitter">
       <a name="facing" val="west"/>
       <a name="fanout" val="16"/>
       <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(150,120)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="In"/>
+    </comp>
+    <comp lib="6" loc="(681,1292)" name="Text">
+      <a name="text" val="ror"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="0" loc="(720,920)" name="Splitter">
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
     </comp>
   </circuit>
@@ -6879,15 +6879,11 @@ c084088
     <wire from="(700,550)" to="(700,610)"/>
     <wire from="(430,400)" to="(430,460)"/>
     <wire from="(720,410)" to="(730,410)"/>
-    <comp lib="0" loc="(750,340)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(760,220)" name="Probe">
+    <comp lib="0" loc="(690,120)" name="Pin">
       <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="Cin"/>
     </comp>
     <comp lib="0" loc="(800,240)" name="Pin">
       <a name="facing" val="west"/>
@@ -6896,6 +6892,60 @@ c084088
       <a name="tristate" val="false"/>
       <a name="label" val="S"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(510,350)" name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(780,540)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(510,390)" name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(230,220)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="A"/>
+    </comp>
+    <comp lib="0" loc="(270,270)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+    </comp>
+    <comp lib="0" loc="(760,220)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="10signed"/>
+    </comp>
+    <comp lib="1" loc="(590,350)" name="OR Gate">
+      <a name="width" val="16"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(680,350)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(230,260)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="B"/>
+    </comp>
+    <comp lib="0" loc="(750,340)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="1" loc="(510,310)" name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="1" loc="(550,240)" name="XOR Gate">
       <a name="width" val="16"/>
@@ -6908,59 +6958,9 @@ c084088
       <a name="label" val="V"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(230,260)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="B"/>
-    </comp>
-    <comp lib="1" loc="(780,540)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(590,350)" name="OR Gate">
-      <a name="width" val="16"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(510,310)" name="AND Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
     <comp lib="0" loc="(270,210)" name="Probe">
       <a name="facing" val="south"/>
       <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="0" loc="(680,350)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="1" loc="(510,350)" name="AND Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(270,270)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="0" loc="(690,120)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="Cin"/>
-    </comp>
-    <comp lib="0" loc="(230,220)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="A"/>
-    </comp>
-    <comp lib="1" loc="(510,390)" name="AND Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(700,610)" name="Pin">
       <a name="facing" val="north"/>
@@ -7045,18 +7045,25 @@ c084088
     <wire from="(410,360)" to="(410,420)"/>
     <wire from="(700,330)" to="(710,330)"/>
     <wire from="(670,80)" to="(670,260)"/>
-    <comp lib="0" loc="(250,230)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="1" loc="(530,200)" name="XOR Gate">
+    <comp lib="0" loc="(210,220)" name="Pin">
       <a name="width" val="8"/>
-      <a name="inputs" val="3"/>
-      <a name="xor" val="odd"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="B"/>
     </comp>
     <comp lib="0" loc="(740,180)" name="Probe">
       <a name="facing" val="south"/>
       <a name="radix" val="10signed"/>
+    </comp>
+    <comp lib="1" loc="(570,310)" name="OR Gate">
+      <a name="width" val="8"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(730,300)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(250,170)" name="Probe">
       <a name="facing" val="south"/>
@@ -7068,6 +7075,11 @@ c084088
       <a name="label" val="V"/>
       <a name="labelloc" val="south"/>
     </comp>
+    <comp lib="1" loc="(490,310)" name="AND Gate">
+      <a name="width" val="8"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
     <comp lib="0" loc="(780,200)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -7076,11 +7088,14 @@ c084088
       <a name="label" val="S"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(210,220)" name="Pin">
+    <comp lib="1" loc="(490,270)" name="AND Gate">
       <a name="width" val="8"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="B"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(250,230)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
     </comp>
     <comp lib="0" loc="(680,570)" name="Pin">
       <a name="facing" val="north"/>
@@ -7094,45 +7109,30 @@ c084088
       <a name="pull" val="down"/>
       <a name="label" val="A"/>
     </comp>
-    <comp lib="1" loc="(490,270)" name="AND Gate">
-      <a name="width" val="8"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(570,310)" name="OR Gate">
-      <a name="width" val="8"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(490,350)" name="AND Gate">
-      <a name="width" val="8"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(760,500)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
     <comp lib="0" loc="(660,310)" name="Splitter">
       <a name="fanout" val="8"/>
       <a name="incoming" val="8"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="1" loc="(490,310)" name="AND Gate">
+    <comp lib="1" loc="(530,200)" name="XOR Gate">
       <a name="width" val="8"/>
+      <a name="inputs" val="3"/>
+      <a name="xor" val="odd"/>
+    </comp>
+    <comp lib="1" loc="(760,500)" name="XOR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(730,300)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(670,80)" name="Pin">
       <a name="facing" val="south"/>
       <a name="tristate" val="false"/>
       <a name="pull" val="down"/>
       <a name="label" val="Cin"/>
+    </comp>
+    <comp lib="1" loc="(490,350)" name="AND Gate">
+      <a name="width" val="8"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
   </circuit>
   <circuit name="branch_logic">
@@ -7250,67 +7250,56 @@ c084088
     <wire from="(820,540)" to="(960,540)"/>
     <wire from="(420,330)" to="(420,390)"/>
     <wire from="(1110,440)" to="(1110,610)"/>
-    <comp lib="6" loc="(330,563)" name="Text">
-      <a name="text" val="N"/>
+    <comp lib="6" loc="(643,302)" name="Text">
+      <a name="text" val="EQ"/>
       <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="1" loc="(570,370)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="1" loc="(990,610)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="6" loc="(330,594)" name="Text">
-      <a name="text" val="Z"/>
-      <a name="font" val="SansSerif plain 18"/>
     </comp>
     <comp lib="1" loc="(600,400)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
     <comp lib="1" loc="(620,600)" name="NOT Gate"/>
-    <comp lib="1" loc="(510,310)" name="AND Gate">
+    <comp lib="6" loc="(330,563)" name="Text">
+      <a name="text" val="N"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="1" loc="(990,530)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="6" loc="(644,392)" name="Text">
-      <a name="text" val="VS"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="0" loc="(120,610)" name="Pin">
-      <a name="width" val="4"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="CVZN"/>
-    </comp>
-    <comp lib="1" loc="(1210,410)" name="OR Gate">
-      <a name="inputs" val="8"/>
-    </comp>
-    <comp lib="6" loc="(1025,678)" name="Text">
-      <a name="text" val="&lt;always&gt;"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="0" loc="(160,320)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
+    <comp lib="1" loc="(700,520)" name="XNOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="2" loc="(740,450)" name="Decoder">
       <a name="selloc" val="tr"/>
       <a name="select" val="2"/>
       <a name="disabled" val="0"/>
     </comp>
-    <comp lib="0" loc="(1300,290)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="go"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(200,320)" name="Splitter">
-      <a name="facing" val="west"/>
+    <comp lib="0" loc="(160,320)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="1" loc="(1280,290)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="2" loc="(370,340)" name="Decoder">
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="6" loc="(644,392)" name="Text">
+      <a name="text" val="VS"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="6" loc="(642,362)" name="Text">
+      <a name="text" val="MI"/>
+      <a name="font" val="SansSerif plain 18"/>
     </comp>
     <comp lib="6" loc="(756,541)" name="Text">
       <a name="text" val="N=V"/>
@@ -7323,51 +7312,57 @@ c084088
       <a name="size" val="30"/>
       <a name="inputs" val="3"/>
     </comp>
-    <comp lib="0" loc="(120,320)" name="Pin">
-      <a name="width" val="4"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="cccc"/>
-    </comp>
-    <comp lib="6" loc="(642,362)" name="Text">
-      <a name="text" val="MI"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="1" loc="(570,370)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="6" loc="(643,302)" name="Text">
-      <a name="text" val="EQ"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="6" loc="(1014,518)" name="Text">
-      <a name="text" val="GE"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="6" loc="(1016,600)" name="Text">
-      <a name="text" val="GT"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="6" loc="(330,623)" name="Text">
-      <a name="text" val="V"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="6" loc="(744,594)" name="Text">
-      <a name="text" val="Z'"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="6" loc="(1016,443)" name="Text">
-      <a name="text" val="HI"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
     <comp lib="0" loc="(160,610)" name="Splitter">
       <a name="fanout" val="4"/>
       <a name="incoming" val="4"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="2" loc="(370,340)" name="Decoder">
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
+    <comp lib="6" loc="(643,335)" name="Text">
+      <a name="text" val="HS/CS"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="6" loc="(1025,678)" name="Text">
+      <a name="text" val="&lt;always&gt;"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="1" loc="(510,310)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="6" loc="(1014,518)" name="Text">
+      <a name="text" val="GE"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="1" loc="(1280,290)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="6" loc="(1016,600)" name="Text">
+      <a name="text" val="GT"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="0" loc="(1300,290)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="go"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="6" loc="(1016,443)" name="Text">
+      <a name="text" val="HI"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="0" loc="(120,610)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="CVZN"/>
+    </comp>
+    <comp lib="6" loc="(330,594)" name="Text">
+      <a name="text" val="Z"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="1" loc="(1210,410)" name="OR Gate">
+      <a name="inputs" val="8"/>
     </comp>
     <comp lib="1" loc="(540,340)" name="AND Gate">
       <a name="size" val="30"/>
@@ -7377,17 +7372,22 @@ c084088
       <a name="text" val="C"/>
       <a name="font" val="SansSerif plain 18"/>
     </comp>
-    <comp lib="1" loc="(700,520)" name="XNOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(200,320)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="appear" val="center"/>
     </comp>
-    <comp lib="6" loc="(643,335)" name="Text">
-      <a name="text" val="HS/CS"/>
+    <comp lib="0" loc="(120,320)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="cccc"/>
+    </comp>
+    <comp lib="6" loc="(744,594)" name="Text">
+      <a name="text" val="Z'"/>
       <a name="font" val="SansSerif plain 18"/>
     </comp>
-    <comp lib="1" loc="(990,530)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="6" loc="(330,623)" name="Text">
+      <a name="text" val="V"/>
+      <a name="font" val="SansSerif plain 18"/>
     </comp>
   </circuit>
   <circuit name="zero8">
@@ -7420,17 +7420,6 @@ c084088
     <wire from="(500,280)" to="(510,280)"/>
     <wire from="(560,290)" to="(570,290)"/>
     <wire from="(530,300)" to="(540,300)"/>
-    <comp lib="0" loc="(500,280)" name="Pin">
-      <a name="width" val="8"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="in"/>
-    </comp>
-    <comp lib="0" loc="(650,280)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="zero"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="1" loc="(630,280)" name="NOR Gate">
       <a name="inputs" val="8"/>
     </comp>
@@ -7438,6 +7427,17 @@ c084088
       <a name="fanout" val="8"/>
       <a name="incoming" val="8"/>
       <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(650,280)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="zero"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(500,280)" name="Pin">
+      <a name="width" val="8"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="in"/>
     </comp>
   </circuit>
   <circuit name="zero16">
@@ -7509,27 +7509,27 @@ c084088
     <wire from="(360,390)" to="(440,390)"/>
     <wire from="(490,360)" to="(570,360)"/>
     <wire from="(560,390)" to="(570,390)"/>
+    <comp lib="1" loc="(630,380)" name="NOR Gate">
+      <a name="inputs" val="8"/>
+    </comp>
+    <comp lib="0" loc="(340,320)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
     <comp lib="0" loc="(720,330)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="zero"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="1" loc="(630,280)" name="NOR Gate">
-      <a name="inputs" val="8"/>
-    </comp>
-    <comp lib="1" loc="(630,380)" name="NOR Gate">
-      <a name="inputs" val="8"/>
-    </comp>
     <comp lib="0" loc="(330,320)" name="Pin">
       <a name="width" val="16"/>
       <a name="tristate" val="false"/>
       <a name="label" val="in"/>
     </comp>
-    <comp lib="0" loc="(340,320)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
+    <comp lib="1" loc="(630,280)" name="NOR Gate">
+      <a name="inputs" val="8"/>
     </comp>
     <comp lib="1" loc="(700,330)" name="AND Gate">
       <a name="size" val="30"/>
@@ -7551,10 +7551,6 @@ c084088
     <wire from="(480,500)" to="(490,500)"/>
     <wire from="(530,500)" to="(540,500)"/>
     <wire from="(580,500)" to="(590,500)"/>
-    <comp lib="0" loc="(530,500)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="8"/>
-    </comp>
     <comp lib="0" loc="(480,500)" name="Pin">
       <a name="width" val="16"/>
       <a name="tristate" val="false"/>
@@ -7569,6 +7565,10 @@ c084088
     </comp>
     <comp lib="0" loc="(580,500)" name="Bit Extender">
       <a name="type" val="sign"/>
+    </comp>
+    <comp lib="0" loc="(530,500)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="8"/>
     </comp>
   </circuit>
   <circuit name="make_byte">
@@ -7590,6 +7590,12 @@ c084088
       <a name="in_width" val="16"/>
       <a name="out_width" val="8"/>
     </comp>
+    <comp lib="0" loc="(480,500)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="In"/>
+    </comp>
+    <comp lib="0" loc="(580,500)" name="Bit Extender"/>
     <comp lib="0" loc="(590,500)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -7597,12 +7603,6 @@ c084088
       <a name="label" val="Out"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(480,500)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="In"/>
-    </comp>
-    <comp lib="0" loc="(580,500)" name="Bit Extender"/>
   </circuit>
   <circuit name="bytes_swap">
     <a name="circuit" val="bytes_swap"/>
@@ -7626,6 +7626,34 @@ c084088
     <wire from="(570,550)" to="(580,550)"/>
     <wire from="(520,510)" to="(530,510)"/>
     <wire from="(600,470)" to="(610,470)"/>
+    <comp lib="0" loc="(520,510)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="In"/>
+    </comp>
+    <comp lib="0" loc="(660,510)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="Out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(530,510)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(610,550)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(650,510)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
     <comp lib="0" loc="(610,470)" name="Splitter">
       <a name="fanout" val="8"/>
       <a name="incoming" val="8"/>
@@ -7637,38 +7665,10 @@ c084088
       <a name="incoming" val="8"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(610,550)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(530,510)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(660,510)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="Out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="0" loc="(570,470)" name="Splitter">
       <a name="facing" val="west"/>
       <a name="fanout" val="8"/>
       <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(520,510)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="In"/>
-    </comp>
-    <comp lib="0" loc="(650,510)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
   </circuit>

--- a/logisim/cdm16/microcode/cdm16_decoder.def
+++ b/logisim/cdm16/microcode/cdm16_decoder.def
@@ -164,20 +164,20 @@ mem2_E:
 mem2_F:
 
 # imm6
-ldsw_p:         mem, data, read, word, fp_asrt0, imm_asrt1, imm_shift, r_latch
-ldsw_n:         mem, data, read, word, fp_asrt0, imm_asrt1, imm_shift, r_latch, imm_extend_negative
+lsw_p:          mem, data, read, word, fp_asrt0, imm_asrt1, imm_shift, r_latch
+lsw_n:          mem, data, read, word, fp_asrt0, imm_asrt1, imm_shift, r_latch, imm_extend_negative
 
-ldsb_p:         mem, data, read, fp_asrt0, imm_asrt1, imm_shift, r_latch
-ldsb_n:         mem, data, read, fp_asrt0, imm_asrt1, imm_shift, r_latch, imm_extend_negative
+lsb_p:          mem, data, read, fp_asrt0, imm_asrt1, r_latch
+lsb_n:          mem, data, read, fp_asrt0, imm_asrt1, r_latch, imm_extend_negative
 
-ldssb_p:        mem, data, read, sign_extend, fp_asrt0, imm_asrt1, imm_shift, r_latch
-ldssb_n:        mem, data, read, sign_extend, fp_asrt0, imm_asrt1, imm_shift, r_latch, imm_extend_negative
+lssb_p:         mem, data, read, sign_extend, fp_asrt0, imm_asrt1, r_latch
+lssb_n:         mem, data, read, sign_extend, fp_asrt0, imm_asrt1, r_latch, imm_extend_negative
 
-stsw_p:         mem, data, word, fp_asrt0, imm_asrt1, imm_shift, r_asrtD
-stsw_n:         mem, data, word, fp_asrt0, imm_asrt1, imm_shift, r_asrtD, imm_extend_negative
+ssw_p:          mem, data, word, fp_asrt0, imm_asrt1, imm_shift, r_asrtD
+ssw_n:          mem, data, word, fp_asrt0, imm_asrt1, imm_shift, r_asrtD, imm_extend_negative
 
-stsb_p:         mem, data, fp_asrt0, imm_asrt1, imm_shift, r_asrtD
-stsb_n:         mem, data, fp_asrt0, imm_asrt1, imm_shift, r_asrtD, imm_extend_negative
+ssb_p:          mem, data, fp_asrt0, imm_asrt1, r_asrtD
+ssb_n:          mem, data, fp_asrt0, imm_asrt1, r_asrtD, imm_extend_negative
 
 ldi_p:          r_latch, imm_asrtD
 ldi_n:          r_latch, imm_asrtD, imm_extend_negative


### PR DESCRIPTION
Assembler should treat all offset values (like in `lsb`, `lsw`...) as count of bytes and then implicitly convert them to right format according to instruction encoding scheme.

+ [x] Make `lsb`, `lssb`, `ssb` count offset in bytes rather then words (cdm16)
+ [x] Update documentation (Closes #24)
+ [x] ~~Unify constant handling~~ Change `lsw` and `ssw` to output half-value argument in cocas