### PR TITLE
Fix overlapping sections with 0 size

### DIFF
--- a/cocas/linker.py
+++ b/cocas/linker.py
@@ -11,16 +11,17 @@ def init_bins(asects: list[ObjectSectionRecord]):
     rsect_bins = []
     last_bin_begin = 0
     for i in range(len(asects)):
-        bin_size = asects[i].address - last_bin_begin
-        if bin_size > 0:
-            rsect_bins.append((last_bin_begin, bin_size))
-        elif bin_size < 0 and len(asects[i].data) > 0:
-            addr1 = asects[i - 1].address
-            addr2 = asects[i].address
-            len1 = len(asects[i - 1].data)
-            len2 = len(asects[i].data)
-            raise CdmLinkException(f'Overlapping sections at {addr1} (size {len1}) and {addr2} (size {len2})')
-        last_bin_begin = asects[i].address + len(asects[i].data)
+        if len(asects[i].data) > 0:
+            bin_size = asects[i].address - last_bin_begin
+            if bin_size > 0:
+                rsect_bins.append((last_bin_begin, bin_size))
+            elif bin_size < 0:
+                addr1 = asects[i - 1].address
+                addr2 = asects[i].address
+                len1 = len(asects[i - 1].data)
+                len2 = len(asects[i].data)
+                raise CdmLinkException(f'Overlapping sections at {addr1} (size {len1}) and {addr2} (size {len2})')
+            last_bin_begin = asects[i].address + len(asects[i].data)
 
     if last_bin_begin < 2 ** 16:
         rsect_bins.append((last_bin_begin, 2 ** 16 - last_bin_begin))

--- a/cocas/linker.py
+++ b/cocas/linker.py
@@ -14,7 +14,7 @@ def init_bins(asects: list[ObjectSectionRecord]):
         bin_size = asects[i].address - last_bin_begin
         if bin_size > 0:
             rsect_bins.append((last_bin_begin, bin_size))
-        elif bin_size < 0:
+        elif bin_size < 0 and len(asects[i].data) > 0:
             addr1 = asects[i - 1].address
             addr2 = asects[i].address
             len1 = len(asects[i - 1].data)


### PR DESCRIPTION
While working with Harvard architecture in cdm8e I stumbled upon a seemingly unwanted behaviour trying to map my RAM memory. This code wouldn't compile:
```
asect 0x00
<some code>

asect 0x00
player_x:
asect 0x01
player_y:
...
```
Even though the section with marks was empty, it was causing Overlapping sections exception:
```
[CdmExceptionTag.LINK] ERROR
Overlapping sections at 0 (size 269) and 0 (size 0)
```
Of course, this would compile this way:
```
asect 0x00
player_x:
<command>
player_y:
<other_code>
```
But that makes for clearly terrible reading and comprehending experience.
This change therefore is targeted to make first example compile while not disrupting anything.