### PR TITLE
Disassembler for CdM processors family

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ After installation you get several components:
 
 - **CLI Programs**
     
-    - `cocas` - universal assembler for CdM processors
+    - `cocas` - assembler for CdM processors
+    - `cocodump` - disassembler for CdM processors
     - `synthm` - secondary decoder synthesis utility
     - *(coming soon)*
 
@@ -55,7 +56,7 @@ Check out our [Getting Stated](/docs/getting-started.md) guide.
 
 ## Documentation
 
-We are wokring on documentation, it will be available soon.
+We are working on documentation, it will be available soon.
 
 However, some docs are available in `docs/` directory.
 
@@ -65,11 +66,11 @@ You can report a bug with GitHub Issues.
 
 - Open new issue [here](https://github.com/cdm-processors/cdm-devkit/issues)
 
-- Use a tempate
+- Use a template
 
 - Provide a proper name and description of a problem
 
-- Provide information on how to repoduce a bug
+- Provide information on how to reproduce a bug
 
 ## Setting up development environment
 
@@ -81,7 +82,7 @@ You can report a bug with GitHub Issues.
 
     > `cocas` uses `ANTLR` to parse assembly language
     >
-    >    - `antlr4-python3-runtime` is needed to run `cocas` and is installed with other dependenices
+    >    - `antlr4-python3-runtime` is needed to run `cocas` and is installed with other dependencies
     >
     >   - However, if you want to fiddle with grammar files and generate new parser you would need to install `antlr4-tools`, this package is installed with development dependencies ([Read more](https://www.antlr.org))
 
@@ -95,7 +96,7 @@ You can report a bug with GitHub Issues.
 
 ## Building
 
-### Building indivilual projects
+### Building individual projects
 
 - **Python-based projects:**
 
@@ -136,19 +137,19 @@ Set `VERSION` variable if you want to specify project version
 >   - Run `choco install make` 
 > - You can read about other installation methods [here](https://gnuwin32.sourceforge.net/packages/make.htm)
 
-## Contibuting
+## Contributing
 
 - All contributions should be done via **pull requests**.
 
-- Commit messages should be written accoring to [these guidelines](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53)
+- Commit messages should be written according to [these guidelines](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53)
 
-- Commit messages should start with a **scope indetifier** - project name surrouneded by square brackets. That will help to determine which project commit belongs to.
+- Commit messages should start with a **scope identifier** - project name surrounded by square brackets. That will help to determine which project commit belongs to.
 
 **Example:** `[cocas] Add new feature`
 
-> Commits related to whlole repository shouldn't use scope indetifier
+> Commits related to whole repository shouldn't use scope identifier
 
-**Possible scope indetifiers are:**
+**Possible scope identifiers are:**
 
 - **General:**
     
@@ -157,14 +158,16 @@ Set `VERSION` variable if you want to specify project version
     - `examples`
     - `tests`
 
-- **Processor implemetations:**
+- **Processor implementations:**
 
     - `cdm*`
 
 - **Projects:**
 
     - `cocas`
-    - `cocemu`
+    - `cocoemu`
+    - `cocodump`
+    - `synthm`
     - `logisim-banked-memory`
     - `logisim-cdm-emulator`
     - `logisim-runner`

--- a/cocodump/args.py
+++ b/cocodump/args.py
@@ -12,9 +12,8 @@ def parse_args():
     parser.add_argument("-t", "--target", type=str, default="cdm16",
                         help="target processor, CdM-16 is default")
 
-    # TODO: IVT Decoding
-    parser.add_argument("--no-ivt", dest="no_ivt", action="store_true",
-                        default=False, help=argparse.SUPPRESS)
+    parser.add_argument("--ivt", dest="ivt", action="store_true",
+                        default=False, help="try to decode IVT")
 
     return parser.parse_args()
 

--- a/cocodump/args.py
+++ b/cocodump/args.py
@@ -21,6 +21,9 @@ def parse_args():
     parser.add_argument("--no-fold", dest="no_fold", action="store_true",
                         default=False, help="don't fold repeating instructions")
 
+    parser.add_argument("--colored", dest="colored", action="store_true",
+                        default=False, help="colorize output")
+
     return parser.parse_args()
 
 

--- a/cocodump/args.py
+++ b/cocodump/args.py
@@ -15,6 +15,12 @@ def parse_args():
     parser.add_argument("--ivt", dest="ivt", action="store_true",
                         default=False, help="try to decode IVT")
 
+    parser.add_argument("--fold-threshold", dest="fold_threshold", type=int, action="store",
+                        default=15, help="minimal amount of repeating instructions to be folded")
+
+    parser.add_argument("--no-fold", dest="no_fold", action="store_true",
+                        default=False, help="don't fold repeating instructions")
+
     return parser.parse_args()
 
 

--- a/cocodump/args.py
+++ b/cocodump/args.py
@@ -25,6 +25,3 @@ def parse_args():
                         default=False, help="colorize output")
 
     return parser.parse_args()
-
-
-args = parse_args()

--- a/cocodump/args.py
+++ b/cocodump/args.py
@@ -1,0 +1,22 @@
+import argparse
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Disassembler for CdM Processors")
+
+    parser.add_argument("source", type=str, nargs='?', help="source file")
+
+    parser.add_argument('-T', '--list-targets', dest="list_targets", action="store_true",
+                        default=False, help='list available targets and exit')
+
+    parser.add_argument("-t", "--target", type=str, default="cdm16",
+                        help="target processor, CdM-16 is default")
+
+    # TODO: IVT Decoding
+    parser.add_argument("--no-ivt", dest="no_ivt", action="store_true",
+                        default=False, help=argparse.SUPPRESS)
+
+    return parser.parse_args()
+
+
+args = parse_args()

--- a/cocodump/asm_emitter.py
+++ b/cocodump/asm_emitter.py
@@ -49,11 +49,11 @@ def fold_instructions(instructions: list[Instruction], fold_threshold: int) -> l
     return folded_instructions
 
 
-def emit_asm(section: DecodedSection, fold: bool = True, fold_threshold: int = 15) -> None:
+def emit_asm(section: DecodedSection, fold: bool = True, fold_threshold: int = 15, colored: bool = False) -> None:
     instructions = section.to_instructions()
 
     if fold:
         instructions = fold_instructions(instructions, fold_threshold)
 
     for inst in instructions:
-        print(inst.emit())
+        print(inst.emit(colored))

--- a/cocodump/asm_emitter.py
+++ b/cocodump/asm_emitter.py
@@ -45,6 +45,7 @@ def fold_instructions(instructions: list[Instruction], fold_threshold: int) -> l
         prev_inst = inst
 
     folded_instructions.pop()
+    instructions.pop()
 
     return folded_instructions
 

--- a/cocodump/asm_emitter.py
+++ b/cocodump/asm_emitter.py
@@ -1,0 +1,59 @@
+from cocodump.base_types import DecodedSection, FoldedInstruction, Instruction
+
+
+def fold_instructions(instructions: list[Instruction], fold_threshold: int) -> list[Instruction]:
+    prev_inst = Instruction("", [])
+    start_idx: int | None = None
+    repeated = False
+
+    inst_acc: list[Instruction] = []
+    folded_instructions: list[Instruction] = []
+
+    instructions.append(Instruction("", []))
+
+    for (num, inst) in enumerate(instructions):
+        num: int
+        inst: Instruction
+
+        if inst.equals_bytes(prev_inst) and not repeated:
+            repeated = True
+            start_idx = num
+
+        if not inst.equals_bytes(prev_inst) and repeated:
+            repeated = False
+
+            region_size = num - start_idx
+
+            if region_size > fold_threshold:
+                folded_instructions.append(FoldedInstruction(
+                    prev_inst,
+                    region_size
+                ))
+
+                folded_instructions.append(prev_inst)
+            else:
+                folded_instructions += inst_acc
+
+            inst_acc.clear()
+
+        if not inst.equals_bytes(prev_inst) and not repeated:
+            folded_instructions.append(inst)
+
+        if inst.equals_bytes(prev_inst) and repeated:
+            inst_acc.append(inst)
+
+        prev_inst = inst
+
+    folded_instructions.pop()
+
+    return folded_instructions
+
+
+def emit_asm(section: DecodedSection, fold: bool = True, fold_threshold: int = 15) -> None:
+    instructions = section.to_instructions()
+
+    if fold:
+        instructions = fold_instructions(instructions, fold_threshold)
+
+    for inst in instructions:
+        print(inst.emit())

--- a/cocodump/base_types.py
+++ b/cocodump/base_types.py
@@ -135,8 +135,4 @@ class InstructionDecoder:
         self.mnemonics = mnemonics
 
     def get_instruction(self, number: int) -> str:
-        try:
-            inst = self.mnemonics[number]
-        except KeyError:
-            inst = "<invalid>"
-        return inst
+        return self.mnemonics.get(number, "<invalid>")

--- a/cocodump/base_types.py
+++ b/cocodump/base_types.py
@@ -28,6 +28,9 @@ class Instruction:
     def add_label(self, label: str) -> None:
         self.labels.append(label)
 
+    def equals_bytes(self, other: "Instruction") -> bool:
+        return self.inst_bytes == other.inst_bytes
+
     def emit_base(self) -> str:
         label_str = "".join([f"{x}:\n" for x in self.labels])
 
@@ -76,6 +79,22 @@ class BranchInstruction(Instruction):
 
 class InterruptVectorInstruction(Instruction):
     TEXT_ALIGN = 40
+
+
+class FoldedInstruction(Instruction):
+    size: int
+
+    def __init__(self, inst: Instruction, size: int) -> None:
+        self.size = size
+        super().__init__(
+            inst.inst,
+            inst.args,
+            inst.addr,
+            inst.inst_bytes
+        )
+
+    def emit(self) -> str:
+        return (' ' * 12) + "..."
 
 
 class DecodedSection:

--- a/cocodump/base_types.py
+++ b/cocodump/base_types.py
@@ -9,6 +9,8 @@ class Instruction:
     labels: list[str]
     comment: str | None
 
+    TEXT_ALIGN = 20
+
     def __init__(self, inst: str, args: list[str], addr: int = None, inst_bytes: bytearray = None) -> None:
         self.inst = inst
         self.args = args
@@ -37,11 +39,14 @@ class Instruction:
 
     def emit(self) -> str:
         string = self.emit_base() + \
-            f"{self.inst} {', '.join(self.args)}"
+                 f"{self.inst} {', '.join(self.args)}"
+
+        content_length = len(self.inst + ', '.join(self.args))
+        align_length = (content_length // self.TEXT_ALIGN + 1) * self.TEXT_ALIGN
 
         if self.comment is not None:
-            string += f"{' ' * (20 - len(self.inst + ', '.join(self.args)))}" \
-                f"# {self.comment}"
+            string += f"{' ' * (align_length - content_length)}" \
+                      f"# {self.comment}"
 
         return string
 
@@ -60,10 +65,17 @@ class BranchInstruction(Instruction):
             return self.emit_base() + \
                 f"{self.inst} {hex(self.br_addr)}"
         else:
+            content_length = len(self.inst + self.br_label)
+            align_length = (content_length // self.TEXT_ALIGN + 1) * self.TEXT_ALIGN
+
             return self.emit_base() + \
                 f"{self.inst} {self.br_label}" \
-                f"{' ' * (20 - len(self.inst + self.br_label))}" \
+                f"{' ' * (align_length - content_length)}" \
                 f"# {self.inst} {self.args[0]}"
+
+
+class InterruptVectorInstruction(Instruction):
+    TEXT_ALIGN = 40
 
 
 class DecodedSection:

--- a/cocodump/base_types.py
+++ b/cocodump/base_types.py
@@ -7,6 +7,7 @@ class Instruction:
     addr: int
     inst_bytes: bytearray
     labels: list[str]
+    comment: str | None
 
     def __init__(self, inst: str, args: list[str], addr: int = None, inst_bytes: bytearray = None) -> None:
         self.inst = inst
@@ -14,6 +15,7 @@ class Instruction:
         self.addr = addr
         self.inst_bytes = inst_bytes
         self.labels = []
+        self.comment = None
 
     def has_labels(self) -> bool:
         return len(self.labels) > 0
@@ -34,8 +36,14 @@ class Instruction:
             f"{' ' * (15 - len(self.inst_bytes) * 3)}"
 
     def emit(self) -> str:
-        return self.emit_base() + \
+        string = self.emit_base() + \
             f"{self.inst} {', '.join(self.args)}"
+
+        if self.comment is not None:
+            string += f"{' ' * (20 - len(self.inst + ', '.join(self.args)))}" \
+                f"# {self.comment}"
+
+        return string
 
 
 class BranchInstruction(Instruction):
@@ -54,11 +62,8 @@ class BranchInstruction(Instruction):
         else:
             return self.emit_base() + \
                 f"{self.inst} {self.br_label}" \
-                f"\t\t# {self.inst} {self.args[0]}"
-
-
-class LabeledInstruction:
-    ...
+                f"{' ' * (20 - len(self.inst + self.br_label))}" \
+                f"# {self.inst} {self.args[0]}"
 
 
 class DecodedSection:

--- a/cocodump/base_types.py
+++ b/cocodump/base_types.py
@@ -99,4 +99,8 @@ class InstructionDecoder:
         self.mnemonics = mnemonics
 
     def get_instruction(self, number: int) -> str:
-        return self.mnemonics[number]
+        try:
+            inst = self.mnemonics[number]
+        except KeyError:
+            inst = "<invalid>"
+        return inst

--- a/cocodump/base_types.py
+++ b/cocodump/base_types.py
@@ -1,0 +1,102 @@
+from cocodump.label_generator import get_label
+
+
+class Instruction:
+    inst: str
+    args: list[str]
+    addr: int
+    inst_bytes: bytearray
+    labels: list[str]
+
+    def __init__(self, inst: str, args: list[str], addr: int = None, inst_bytes: bytearray = None) -> None:
+        self.inst = inst
+        self.args = args
+        self.addr = addr
+        self.inst_bytes = inst_bytes
+        self.labels = []
+
+    def has_labels(self) -> bool:
+        return len(self.labels) > 0
+
+    def get_label(self) -> str:
+        return self.labels[0]
+
+    def add_label(self, label: str) -> None:
+        self.labels.append(label)
+
+    def emit_base(self) -> str:
+        label_str = "".join([f"{x}:\n" for x in self.labels])
+
+        return label_str + \
+            f"{' ' * 2}" \
+            f"{format(self.addr, '04x')}: " \
+            f"{' '.join([format(x, '02x') for x in self.inst_bytes])}" \
+            f"{' ' * (15 - len(self.inst_bytes) * 3)}"
+
+    def emit(self) -> str:
+        return self.emit_base() + \
+            f"{self.inst} {', '.join(self.args)}"
+
+
+class BranchInstruction(Instruction):
+    br_addr: int
+    br_label: str | None
+
+    def __init__(self, inst: str, args: list[str], addr: int = None, br_addr: int = None) -> None:
+        super().__init__(inst, args, addr)
+        self.br_addr = br_addr
+        self.br_label = None
+
+    def emit(self) -> str:
+        if self.br_label is None:
+            return self.emit_base() + \
+                f"{self.inst} {hex(self.br_addr)}"
+        else:
+            return self.emit_base() + \
+                f"{self.inst} {self.br_label}" \
+                f"\t\t# {self.inst} {self.args[0]}"
+
+
+class LabeledInstruction:
+    ...
+
+
+class DecodedSection:
+    memory: dict[int, Instruction]
+
+    def __init__(self) -> None:
+        self.memory = dict()
+
+    def add_inst(self, inst: Instruction):
+        self.memory[inst.addr] = inst
+
+    def place_labels(self) -> None:
+
+        for loc in self.memory.keys():
+            curr_inst = self.memory[loc]
+
+            if isinstance(curr_inst, BranchInstruction):
+                br_inst = self.memory.get(curr_inst.br_addr)
+
+                if br_inst is None:
+                    continue
+
+                if br_inst.has_labels():
+                    curr_inst.br_label = br_inst.get_label()
+                else:
+                    new_label = get_label()
+                    curr_inst.br_label = new_label
+                    br_inst.add_label(new_label)
+
+    def to_instructions(self) -> list[Instruction]:
+        return [self.memory[x] for x in self.memory.keys()]
+
+
+class InstructionDecoder:
+    mnemonics: dict[int, str]
+
+    def __init__(self, mnemonics: dict[int, str]) -> None:
+        self.mnemonics = mnemonics
+
+    def get_instruction(self, number: int) -> str:
+        return self.mnemonics[number]

--- a/cocodump/colorizer.py
+++ b/cocodump/colorizer.py
@@ -1,0 +1,22 @@
+import string
+
+from colorama.ansi import Fore, Style
+
+
+def colorize(token: str, color: "Fore | Style") -> str:
+    return f"{color}{token}{Style.RESET_ALL}"
+
+
+SPECIAL_REGISTERS = ["sp", "pc", "fp"]
+
+
+def colorize_argument(arg: str) -> str:
+    if (len(arg) >= 2 and arg.startswith('r') and arg[1].isdigit()) or \
+            arg in SPECIAL_REGISTERS:
+        return colorize(arg, Style.NORMAL)
+
+    if arg.isdecimal() or (len(arg) > 1 and arg[1:].isdecimal()) or \
+            (len(arg) > 2 and arg.startswith("0x") and all(c in string.hexdigits for c in arg[2:])):
+        return colorize(arg, Style.NORMAL)
+
+    return colorize(arg, Fore.LIGHTYELLOW_EX)

--- a/cocodump/label_generator.py
+++ b/cocodump/label_generator.py
@@ -1,9 +1,16 @@
-label_counter = 0
+from collections.abc import Iterator
+
+
+def get_label_generator(prefix: str) -> Iterator[str]:
+    label_counter = 0
+
+    while True:
+        yield f"{prefix}{label_counter}"
+        label_counter += 1
+
+
+_label_generator = get_label_generator("L")
 
 
 def get_label() -> str:
-    global label_counter
-
-    label = f"L{label_counter}"
-    label_counter += 1
-    return label
+    return next(_label_generator)

--- a/cocodump/label_generator.py
+++ b/cocodump/label_generator.py
@@ -1,0 +1,9 @@
+label_counter = 0
+
+
+def get_label() -> str:
+    global label_counter
+
+    label = f"L{label_counter}"
+    label_counter += 1
+    return label

--- a/cocodump/main.py
+++ b/cocodump/main.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 
-from cocodump.args import args, parse_args
+from cocodump.args import parse_args
 from cocodump.asm_emitter import emit_asm
 from cocodump.reader import read_img
 from cocodump.target_loader import import_target_decoder, list_target_decoders, normalize_target_name
 
 
 def main():
-    parse_args()
+    args = parse_args()
 
     available_targets = list_target_decoders()
 

--- a/cocodump/main.py
+++ b/cocodump/main.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from cocodump.args import args, parse_args
+from cocodump.asm_emitter import emit_asm
 from cocodump.reader import read_img
 from cocodump.target_loader import import_target_decoder, list_target_decoders, normalize_target_name
 
@@ -29,12 +30,11 @@ def main():
 
     raw_bytes = read_img(Path(args.source))
 
-    decoded_bytes = decoder.decode(raw_bytes, args.ivt)
+    decoded_section = decoder.decode(raw_bytes, args.ivt)
 
-    decoded_bytes.place_labels()
+    decoded_section.place_labels()
 
-    for inst in decoded_bytes.to_instructions():
-        print(inst.emit())
+    emit_asm(decoded_section, not args.no_fold, args.fold_threshold)
 
 
 if __name__ == "__main__":

--- a/cocodump/main.py
+++ b/cocodump/main.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from cocodump.args import args, parse_args
+from cocodump.reader import read_img
+from cocodump.target_loader import import_target_decoder, list_target_decoders
+
+
+def main():
+    parse_args()
+
+    available_targets = list_target_decoders()
+
+    if args.list_targets:
+        print(f"Available targets: {', '.join(available_targets)}")
+        exit(0)
+
+    if args.target not in available_targets:
+        print(f"Ivalid target: {args.target}")
+        print(f"Available targets: {', '.join(available_targets)}")
+        exit(1)
+
+    decoder = import_target_decoder(args.target)
+
+    if args.source is None:
+        print("No files provided!")
+        exit(0)
+
+    raw_bytes = read_img(Path(args.source))
+
+    decoded_bytes = decoder.decode(raw_bytes)
+
+    decoded_bytes.place_labels()
+
+    for inst in decoded_bytes.to_instructions():
+        print(inst.emit())
+
+
+if __name__ == "__main__":
+    main()

--- a/cocodump/main.py
+++ b/cocodump/main.py
@@ -29,7 +29,7 @@ def main():
 
     raw_bytes = read_img(Path(args.source))
 
-    decoded_bytes = decoder.decode(raw_bytes)
+    decoded_bytes = decoder.decode(raw_bytes, args.ivt)
 
     decoded_bytes.place_labels()
 

--- a/cocodump/main.py
+++ b/cocodump/main.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from cocodump.args import args, parse_args
 from cocodump.reader import read_img
-from cocodump.target_loader import import_target_decoder, list_target_decoders
+from cocodump.target_loader import import_target_decoder, list_target_decoders, normalize_target_name
 
 
 def main():
@@ -10,16 +10,18 @@ def main():
 
     available_targets = list_target_decoders()
 
+    target = normalize_target_name(args.target)
+
     if args.list_targets:
         print(f"Available targets: {', '.join(available_targets)}")
         exit(0)
 
-    if args.target not in available_targets:
-        print(f"Ivalid target: {args.target}")
+    if target not in available_targets:
+        print(f"Invalid target: {target}")
         print(f"Available targets: {', '.join(available_targets)}")
         exit(1)
 
-    decoder = import_target_decoder(args.target)
+    decoder = import_target_decoder(target)
 
     if args.source is None:
         print("No files provided!")

--- a/cocodump/main.py
+++ b/cocodump/main.py
@@ -30,6 +30,10 @@ def main():
 
     raw_bytes = read_img(Path(args.source))
 
+    if len(raw_bytes) == 0:
+        print(f"Got empty image: {args.source}")
+        exit(0)
+
     decoded_section = decoder.decode(raw_bytes, args.ivt)
 
     decoded_section.place_labels()

--- a/cocodump/main.py
+++ b/cocodump/main.py
@@ -34,7 +34,7 @@ def main():
 
     decoded_section.place_labels()
 
-    emit_asm(decoded_section, not args.no_fold, args.fold_threshold)
+    emit_asm(decoded_section, not args.no_fold, args.fold_threshold, args.colored)
 
 
 if __name__ == "__main__":

--- a/cocodump/reader.py
+++ b/cocodump/reader.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def read_img(file: Path) -> bytearray:
+    lines = file.read_text().split('\n')[1:]
+
+    image: bytearray = bytearray()
+
+    for line in lines:
+
+        if line.startswith('#') or len(line) == 0:
+            pass
+        elif '*' in line:
+            (amount, byte) = line.split('*')
+            amount = int(amount)
+            byte = int(byte, 16)
+
+            for _ in range(amount):
+                image.append(byte)
+        else:
+            image.append(int(line, 16))
+
+    return image

--- a/cocodump/target_loader.py
+++ b/cocodump/target_loader.py
@@ -28,3 +28,7 @@ def list_target_decoders() -> list[str]:
     available_targets = list(map(lambda x: str(x.name), targets_dir.iterdir()))
 
     return available_targets
+
+
+def normalize_target_name(name: str) -> str:
+    return name.replace('-', '').lower()

--- a/cocodump/target_loader.py
+++ b/cocodump/target_loader.py
@@ -1,29 +1,25 @@
 import importlib
-from collections.abc import Callable
 from pathlib import Path
+from typing import Protocol, runtime_checkable
 
 from cocodump.base_types import DecodedSection
 
 
-class TargetDecoder:
-    _decode_func: Callable[[bytearray, bool], DecodedSection]
-
-    def __init__(self, func: Callable[[bytearray, bool], DecodedSection]) -> None:
-        self._decode_func = func
-
-    def decode(self, image: bytearray, has_ivt: bool = False) -> DecodedSection:
-        return self._decode_func(image, has_ivt)
+@runtime_checkable
+class TargetDecoder(Protocol):
+    def decode(self, image: bytearray, has_ivt: bool = False) -> DecodedSection: ...
 
 
-def import_target_decoder(target_name: str):
-    decoder_func = \
-        importlib.import_module(f"cocodump.targets.{target_name}.decoder").decode
+def import_target_decoder(target_name: str) -> TargetDecoder:
+    decoder_module = importlib.import_module(f"cocodump.targets.{target_name}.decoder")
 
-    return TargetDecoder(decoder_func)
+    if isinstance(decoder_module, TargetDecoder):
+        return decoder_module
+    else:
+        raise TypeError("Module is not a valid target decoder")
 
 
 def list_target_decoders() -> list[str]:
-    # TODO: check target
     targets_dir = Path(__file__).parent / "targets"
     available_targets = list(map(lambda x: str(x.name), targets_dir.iterdir()))
 

--- a/cocodump/target_loader.py
+++ b/cocodump/target_loader.py
@@ -6,13 +6,13 @@ from cocodump.base_types import DecodedSection
 
 
 class TargetDecoder:
-    _decode_func: Callable[[bytearray], DecodedSection]
+    _decode_func: Callable[[bytearray, bool], DecodedSection]
 
-    def __init__(self, func: Callable[[bytearray], DecodedSection]) -> None:
+    def __init__(self, func: Callable[[bytearray, bool], DecodedSection]) -> None:
         self._decode_func = func
 
-    def decode(self, image: bytearray) -> DecodedSection:
-        return self._decode_func(image)
+    def decode(self, image: bytearray, has_ivt: bool = False) -> DecodedSection:
+        return self._decode_func(image, has_ivt)
 
 
 def import_target_decoder(target_name: str):

--- a/cocodump/target_loader.py
+++ b/cocodump/target_loader.py
@@ -1,0 +1,30 @@
+import importlib
+from collections.abc import Callable
+from pathlib import Path
+
+from cocodump.base_types import DecodedSection
+
+
+class TargetDecoder:
+    _decode_func: Callable[[bytearray], DecodedSection]
+
+    def __init__(self, func: Callable[[bytearray], DecodedSection]) -> None:
+        self._decode_func = func
+
+    def decode(self, image: bytearray) -> DecodedSection:
+        return self._decode_func(image)
+
+
+def import_target_decoder(target_name: str):
+    decoder_func = \
+        importlib.import_module(f"cocodump.targets.{target_name}.decoder").decode
+
+    return TargetDecoder(decoder_func)
+
+
+def list_target_decoders() -> list[str]:
+    # TODO: check target
+    targets_dir = Path(__file__).parent / "targets"
+    available_targets = list(map(lambda x: str(x.name), targets_dir.iterdir()))
+
+    return available_targets

--- a/cocodump/targets/cdm16/asm.py
+++ b/cocodump/targets/cdm16/asm.py
@@ -1,0 +1,73 @@
+from enum import Enum, auto
+
+from cocodump.base_types import InstructionDecoder
+
+
+class InstructionGroup(Enum):
+    ZERO_OP = auto()
+    ONE_OP = auto()
+    TWO_OP = auto()
+    MEM_2 = auto()
+    IMM_6 = auto()
+    IMM_9 = auto()
+    MEM_3 = auto()
+    BR_ABS = auto()
+    SHIFTS = auto()
+    ALU_2 = auto()
+    ALU_3_IND = auto()
+    ALU_3 = auto()
+    BR_REL = auto()
+
+
+inst_decoders: dict[InstructionGroup, InstructionDecoder] = {
+    InstructionGroup.ZERO_OP: InstructionDecoder({0: "zero", 1: "res", 2: "res", 3: "res", 4: "halt", 5: "wait",
+                                                  6: "ei", 7: "di", 8: "jsr", 9: "rti", 10: "pupc", 11: "popc",
+                                                  12: "pusp", 13: "posp", 14: "pups", 15: "pops"}),
+
+    InstructionGroup.ONE_OP: InstructionDecoder({0: "push", 1: "pop", 2: "ldi", 3: "jsrr", 4: "ldsp", 5: "stsp",
+                                                 6: "ldps", 7: "stps", 8: "ldpc", 9: "stpc", 10: "addsp"}),
+
+    InstructionGroup.TWO_OP: InstructionDecoder({0: "move"}),
+
+    InstructionGroup.MEM_2: InstructionDecoder({0: "ldw", 1: "ldb", 2: "ldsb", 3: "lcw", 4: "lcb", 5: "lcsb",
+                                                6: "stw", 7: "stb"}),
+
+    InstructionGroup.IMM_6: InstructionDecoder({0: "lsw", 1: "lsw", 2: "lsb", 3: "lsb", 4: "lssb", 5: "lssb",
+                                                6: "ssw", 7: "ssw", 8: "ssb", 9: "ssb", 10: "ldi", 11: "ldi",
+                                                12: "add", 13: "add", 14: "cmp", 15: "cmp"}),
+
+    InstructionGroup.IMM_9: InstructionDecoder({0: "int", 1: "reset", 2: "push", 3: "push", 4: "addsp", 5: "addsp",
+                                                6: "jsr", 7: "jsr"}),
+
+    InstructionGroup.MEM_3: InstructionDecoder({0: "ldw", 1: "ldb", 2: "ldsb", 3: "lcw", 4: "lcb", 5: "lcsb",
+                                                6: "stw", 7: "stb"}),
+
+    InstructionGroup.BR_ABS: InstructionDecoder({0: "beq", 1: "bne", 2: "bhs", 3: "blo", 4: "bmi", 5: "bpl",
+                                                 6: "bvs", 7: "bvc", 8: "bhi", 9: "bls", 10: "bge", 11: "blt",
+                                                 12: "bgt", 13: "ble", 14: "br", 15: "nop"}),
+
+    InstructionGroup.SHIFTS: InstructionDecoder({0: "shl", 1: "shr", 2: "shra", 3: "rol", 4: "ror", 5: "rcl",
+                                                6: "rcr"}),
+
+    InstructionGroup.ALU_2: InstructionDecoder({0: "neg", 1: "not", 2: "sxt", 3: "scl"}),
+
+    InstructionGroup.ALU_3_IND: InstructionDecoder({0: "bit", 6: "cmp"}),
+
+    InstructionGroup.ALU_3: InstructionDecoder({0: "and", 1: "or", 2: "xor", 3: "bic", 4: "add", 5: "addc",
+                                                6: "sub", 7: "subc"}),
+
+    InstructionGroup.BR_REL: InstructionDecoder({0: "beq", 1: "bne", 2: "bhs", 3: "blo", 4: "bmi", 5: "bpl",
+                                                 6: "bvs", 7: "bvc", 8: "bhi", 9: "bls", 10: "bge", 11: "blt",
+                                                 12: "bgt", 13: "ble", 14: "br", 15: "nop"})
+}
+
+registers = {
+    0: "r0",
+    1: "r1",
+    2: "r2",
+    3: "r3",
+    4: "r4",
+    5: "r5",
+    6: "r6",
+    7: "fp",
+}

--- a/cocodump/targets/cdm16/decoder.py
+++ b/cocodump/targets/cdm16/decoder.py
@@ -1,0 +1,282 @@
+from cocodump.base_types import BranchInstruction, DecodedSection, Instruction
+from cocodump.targets.cdm16.asm import InstructionGroup, inst_decoders, registers
+
+
+def normalize_imm6(val: int):
+    return (-1 << 6) | val
+
+
+def normalize_imm9(val: int):
+    return (-1 << 9) | val
+
+
+def decode_inst(instruction: int) -> tuple[Instruction, InstructionGroup]:
+    inst_group = (instruction >> 13) & 0b111  # higher 3 bits
+
+    X = (instruction >> 12) & 1  # 12th bit
+    Y = (instruction >> 11) & 1  # 11th bit
+
+    op_type_d0 = instruction & 0b1111
+    op_type_d1 = (instruction >> 3) & 0b1111
+    op_type_d2 = (instruction >> 6) & 0b1111
+    op_type_d3 = (instruction >> 9) & 0b1111
+
+    br_abs_flags_d = op_type_d0
+    br_rel_flags_d = op_type_d3
+
+    rd_d = instruction & 0b111
+    rs0_d = (instruction >> 3) & 0b111
+    rs1_d = (instruction >> 6) & 0b111
+
+    alu_op_d0 = rs1_d
+    alu_op_d1 = (instruction >> 9) & 0b111
+
+    imm6_d = (instruction >> 3) & 0b111111
+    imm9_d = instruction & 0b111111111
+
+    shift_count_d = rs1_d
+
+    decoded_inst_group: InstructionGroup | None = None
+    decoded_instruction: Instruction | None = None
+
+    match inst_group:
+
+        case 0b000:
+            if X:
+                decoded_inst_group = InstructionGroup.SHIFTS
+                decoded_instruction = Instruction(
+                    inst_decoders[decoded_inst_group].get_instruction(alu_op_d1),
+                    [
+                        registers[rs0_d],
+                        registers[rd_d],
+                        str(shift_count_d + 1)
+                    ]
+                )
+            else:
+                if Y:
+                    decoded_inst_group = InstructionGroup.BR_ABS
+                    decoded_instruction = BranchInstruction(
+                        inst_decoders[decoded_inst_group].get_instruction(br_abs_flags_d),
+                        []
+                    )
+                else:
+                    decoded_inst_group = InstructionGroup.ZERO_OP
+                    inst = inst_decoders[decoded_inst_group].get_instruction(op_type_d0)
+
+                    if inst == "jsr":
+                        decoded_instruction = BranchInstruction(
+                            inst,
+                            []
+                        )
+                    else:
+                        decoded_instruction = Instruction(
+                            inst,
+                            []
+                        )
+
+        case 0b001:
+            decoded_inst_group = InstructionGroup.ONE_OP
+            decoded_instruction = Instruction(
+                inst_decoders[decoded_inst_group].get_instruction(op_type_d1),
+                [registers[rd_d]]
+            )
+
+        case 0b010:
+            if X:
+                if Y:
+                    decoded_inst_group = InstructionGroup.ALU_2
+                    decoded_instruction = Instruction(
+                        inst_decoders[decoded_inst_group].get_instruction(alu_op_d0),
+                        [
+                            registers[rs0_d],
+                            registers[rd_d]
+                        ]
+                    )
+                else:
+                    decoded_inst_group = InstructionGroup.MEM_2
+                    decoded_instruction = Instruction(
+                        inst_decoders[decoded_inst_group].get_instruction(op_type_d2),
+                        [
+                            registers[rs0_d],
+                            registers[rd_d]
+                        ]
+                    )
+            else:
+                if Y:
+                    decoded_inst_group = InstructionGroup.ALU_3_IND
+                    decoded_instruction = Instruction(
+                        inst_decoders[decoded_inst_group].get_instruction(alu_op_d0),
+                        [
+                            registers[rs0_d],
+                            registers[rd_d]
+                        ]
+                    )
+                else:
+                    decoded_inst_group = InstructionGroup.TWO_OP
+                    decoded_instruction = Instruction(
+                        inst_decoders[decoded_inst_group].get_instruction(op_type_d2),
+                        [
+                            registers[rs0_d],
+                            registers[rd_d]
+                        ]
+                    )
+
+        case 0b011:
+            decoded_inst_group = InstructionGroup.IMM_6
+            inst = inst_decoders[decoded_inst_group].get_instruction(op_type_d3)
+
+            mult_inst = ["lsw", "ssw"]
+
+            imm = imm6_d if op_type_d3 % 2 == 0 else normalize_imm6(imm6_d)
+
+            if inst in mult_inst:
+                imm *= 2
+
+            decoded_instruction = Instruction(
+                inst,
+                [
+                    registers[rd_d],
+                    str(imm)
+                ]
+            )
+
+        case 0b100:
+            decoded_inst_group = InstructionGroup.IMM_9
+            inst = inst_decoders[decoded_inst_group].get_instruction(op_type_d3)
+
+            mult_inst = ["addsp", "jsr"]
+
+            imm = imm9_d
+
+            if inst not in ["int", "reset"]:
+                imm = imm9_d if op_type_d3 % 2 == 0 else normalize_imm9(imm9_d)
+
+                if inst in mult_inst:
+                    imm *= 2
+
+            if inst == "jsr":
+                decoded_instruction = BranchInstruction(
+                    inst,
+                    [str(imm) if imm < 0 else '+' + str(imm)]
+                )
+            else:
+                decoded_instruction = Instruction(
+                    inst,
+                    [str(imm)]
+                )
+
+        case 0b101:
+            if X:
+                decoded_inst_group = InstructionGroup.ALU_3
+                decoded_instruction = Instruction(
+                    inst_decoders[decoded_inst_group].get_instruction(alu_op_d1),
+                    [
+                        registers[rs0_d],
+                        registers[rs1_d],
+                        registers[rd_d]
+                    ]
+                )
+            else:
+                decoded_inst_group = InstructionGroup.MEM_3
+                decoded_instruction = Instruction(
+                    inst_decoders[decoded_inst_group].get_instruction(op_type_d3),
+                    [
+                        registers[rs0_d],
+                        registers[rs1_d],
+                        registers[rd_d]
+                    ]
+                )
+
+        case 0b110:
+            if br_rel_flags_d == 0xF:
+                decoded_inst_group = InstructionGroup.ZERO_OP
+
+                decoded_instruction = Instruction(
+                    "nop",
+                    []
+                )
+            else:
+                decoded_inst_group = InstructionGroup.BR_REL
+
+                decoded_instruction = BranchInstruction(
+                    inst_decoders[decoded_inst_group].get_instruction(br_rel_flags_d),
+                    [str(normalize_imm9(imm9_d) * 2)]
+                )
+
+        case 0b111:
+            if br_rel_flags_d == 0xF:
+                decoded_inst_group = InstructionGroup.ZERO_OP
+
+                decoded_instruction = Instruction(
+                    "nop",
+                    []
+                )
+            else:
+                decoded_inst_group = InstructionGroup.BR_REL
+
+                decoded_instruction = BranchInstruction(
+                    inst_decoders[decoded_inst_group].get_instruction(br_rel_flags_d),
+                    ['+' + str(imm9_d * 2)]
+                )
+
+    if decoded_instruction is None:
+        decoded_instruction = Instruction("<invalid>", [])
+
+    return decoded_instruction, decoded_inst_group
+
+
+def decode(image: bytearray) -> DecodedSection:
+    section = DecodedSection()
+
+    image.append(0)
+
+    section_iter = iter(image)
+    current_addr = 0
+
+    while True:
+        try:
+            lower_byte = next(section_iter)
+            higher_byte = next(section_iter)
+
+            word = (higher_byte << 8) | lower_byte
+
+            (inst, inst_group) = decode_inst(word)
+
+            inst.addr = current_addr
+            inst.inst_bytes = [lower_byte, higher_byte]
+
+            current_addr += 2
+
+            if inst_group == InstructionGroup.BR_REL or \
+                    (inst_group == InstructionGroup.IMM_9 and inst.inst == "jsr"):
+                inst: BranchInstruction
+                inst.br_addr = current_addr + int(inst.args[0])
+
+            if inst_group == InstructionGroup.BR_ABS or \
+                    (inst_group == InstructionGroup.ONE_OP and inst.inst == "ldi") or \
+                    (inst_group == InstructionGroup.ZERO_OP and inst.inst == "jsr"):
+                lower_byte = next(section_iter)
+                higher_byte = next(section_iter)
+
+                inst.inst_bytes.append(lower_byte)
+                inst.inst_bytes.append(higher_byte)
+
+                word = (higher_byte << 8) | lower_byte
+
+                if inst_group == InstructionGroup.BR_ABS or \
+                        (inst_group == InstructionGroup.ZERO_OP and inst.inst == "jsr"):
+                    inst: BranchInstruction
+                    inst.args.append(hex(word))
+                    inst.br_addr = int(inst.args[0], 16)
+
+                if inst_group == InstructionGroup.ONE_OP and inst.inst == "ldi":
+                    inst.args.append(hex(word))
+
+                current_addr += 2
+
+            section.add_inst(inst)
+
+        except StopIteration:
+            break
+
+    return section

--- a/cocodump/targets/cdm16/decoder.py
+++ b/cocodump/targets/cdm16/decoder.py
@@ -242,6 +242,9 @@ def decode(image: bytearray) -> DecodedSection:
 
             (inst, inst_group) = decode_inst(word)
 
+            if inst.inst == "<invalid>":
+                inst: Instruction = Instruction("<invalid>", [])
+
             inst.addr = current_addr
             inst.inst_bytes = [lower_byte, higher_byte]
 

--- a/cocodump/targets/cdm16/decoder.py
+++ b/cocodump/targets/cdm16/decoder.py
@@ -263,14 +263,12 @@ def decode(image: bytearray) -> DecodedSection:
 
                 word = (higher_byte << 8) | lower_byte
 
+                inst.args.append(hex(word))
+
                 if inst_group == InstructionGroup.BR_ABS or \
                         (inst_group == InstructionGroup.ZERO_OP and inst.inst == "jsr"):
                     inst: BranchInstruction
-                    inst.args.append(hex(word))
-                    inst.br_addr = int(inst.args[0], 16)
-
-                if inst_group == InstructionGroup.ONE_OP and inst.inst == "ldi":
-                    inst.args.append(hex(word))
+                    inst.br_addr = word
 
                 current_addr += 2
 

--- a/cocodump/targets/cdm16/ivt.py
+++ b/cocodump/targets/cdm16/ivt.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class InterruptVector:
+    addr: int
+    label: str
+    desc: str
+
+
+ivt_descriptions: list[InterruptVector] = [
+    InterruptVector(0x00, "_start", "Startup/Reset vector"),
+    InterruptVector(0x04, "_unaligned_sp", "Unaligned SP"),
+    InterruptVector(0x08, "_unaligned_pc", "Unaligned PC"),
+    InterruptVector(0x0C, "_invalid_instruction", "Invalid instruction"),
+    InterruptVector(0x10, "_double_fault", "Double fault")
+]

--- a/cocodump/targets/cdm16/ivt.py
+++ b/cocodump/targets/cdm16/ivt.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(slots=True)
 class InterruptVector:
     addr: int
     label: str

--- a/cocodump/targets/cdm16/reference_programs/all_inst.asm
+++ b/cocodump/targets/cdm16/reference_programs/all_inst.asm
@@ -1,0 +1,110 @@
+asect 0
+
+    dw 0
+    halt
+    wait
+    ei
+    di
+    jsr 0xff00
+    rti
+    pupc
+    popc
+    pusp
+    posp
+    pups
+    pops
+
+    push r1
+    pop r2
+    ldi r3, 0xaabb
+    jsrr r4
+    ldsp r5
+    stsp r6
+    ldps fp
+    stps r0
+    ldpc r1
+    stpc r2
+    addsp r3
+
+    move r4, r5
+
+    ldw r1, r2
+    ldb r2, r3
+    ldsb r3, r4
+    lcw r1, r2
+    lcb r2, r3
+    lcsb r3, r4
+    stw r5, r6
+    stb r6, fp
+
+    lsw r1, 16
+    lsw r2, -16
+    lsb r3, 17
+    lsb r4, -17
+    lssb r5, 18
+    lssb r6, -19
+    ssw fp, 10
+    ssw r1, -12
+    ssb r2, 12
+    ssb r3, -13
+    ldi r1, 5
+    ldi r2, -5
+    add r3, 15
+    sub r3, 15
+    cmp r5, 10
+    cmp fp, -15
+
+    int 15
+    reset 2
+    push 15
+    push -17
+    addsp 16
+    addsp -18
+
+    jsr jsr_label
+    nop
+jsr_label:
+    jsr jsr_label
+
+    ldw r1, r1, r2
+    ldb r2, r2, r3
+    ldsb r3, r3, r4
+    lcw r1, r1, r2
+    lcb r2, r2, r3
+    lcsb r3, r3, r4
+    stw r5, r5, r6
+    stb r6, r6, fp
+
+    br 0xff00
+
+    shl r1
+    shr r1, 2
+    shra r2, r3, 3
+    rol r3, r4, 4
+    ror r4, r5, 5
+    rcl r3, r4, 4
+    rcr r4, r5, 5
+
+    neg r0
+    not r1, r2
+    sxt r2, r3
+    scl r3, r4
+
+    bit r3, r2
+    cmp r5, r4
+
+    and r0, r1
+    or r1, r2, r3
+    xor r1, r2, r3
+    bic r1, r2, r3
+    add r1, r2, r3
+    addc r1, r2, r3
+    sub r1, r2, r3
+    subc r1, r2, r3
+
+    br br_label
+    nop
+br_label:
+    br br_label
+
+end.

--- a/cocodump/targets/cdm16/reference_programs/branches.asm
+++ b/cocodump/targets/cdm16/reference_programs/branches.asm
@@ -1,0 +1,37 @@
+asect 0
+
+start:
+    nop
+    br start
+    nop
+    br start
+    nop
+    br start
+    nop
+    br start
+
+    ldi r0, 0xaabb
+    nop
+    nop
+
+    if
+        tst r0
+    is nz
+        dec r0
+        add r0, 16
+    else
+        inc r0
+        sub r1, 10
+    fi
+
+    int 90
+
+    while
+        tst r0
+    stays nz
+        dec r0
+    wend
+
+    halt
+
+end.

--- a/cocodump/targets/cdm16/reference_programs/ivt.asm
+++ b/cocodump/targets/cdm16/reference_programs/ivt.asm
@@ -1,0 +1,35 @@
+asect 0
+main: ext               # Declare labels
+default_handler: ext    # as external
+
+# Interrupt vector table (IVT)
+# Place a vector to program start and
+# map all internal exceptions to default_handler
+dc main, 0              # Startup/Reset vector
+dc default_handler, 0   # Unaligned SP
+dc default_handler, 0   # Unaligned PC
+dc default_handler, 0   # Invalid instruction
+dc default_handler, 0   # Double fault
+align 0x80              # Reserve space for the rest
+                        # of IVT
+
+# Exception handlers section
+rsect exc_handlers
+
+# This handler halts processor
+default_handler>
+    halt
+
+# Main program section
+rsect main
+
+default_handler: ext
+
+main>
+    ldi r0, 15
+    add r0, r0, r0
+    shr r5
+    br main
+    br default_handler
+
+end.

--- a/cocodump/targets/cdm8/asm.py
+++ b/cocodump/targets/cdm8/asm.py
@@ -1,0 +1,45 @@
+from enum import IntEnum
+
+from cocodump.base_types import InstructionDecoder
+
+
+class InstructionGroup(IntEnum):
+    DIRECT = 0x0
+    UNARY_ARITH = 0x8
+    SHIFTS = 0x9
+    ST = 0xA
+    LD = 0xB
+    PUSH_GR = 0xC
+    LDI_GR = 0xD
+    BRANCHES = 0xE
+    LDC = 0xF
+    SP_GROUP = 0xCC
+
+
+inst_decoders: dict[InstructionGroup | int, InstructionDecoder] = {
+    InstructionGroup.DIRECT: InstructionDecoder({0: "move", 1: "add", 2: "addc", 3: "sub", 4: "and",
+                                                 5: "or", 6: "xor", 7: "cmp"}),
+
+    InstructionGroup.UNARY_ARITH: InstructionDecoder({0: "not", 1: "neg", 2: "dec", 3: "inc"}),
+
+    InstructionGroup.SHIFTS: InstructionDecoder({0: "shr", 1: "shl", 2: "shra", 3: "rol"}),
+
+    InstructionGroup.PUSH_GR: InstructionDecoder({0: "push", 1: "pop", 2: "ldsa"}),
+
+    InstructionGroup.SP_GROUP: InstructionDecoder({0: "addsp", 1: "setsp", 2: "pushall", 3: "popall"}),
+
+    InstructionGroup.LDI_GR: InstructionDecoder({4: "halt", 5: "wait", 6: "jsr", 7: "rts",
+                                                 8: "ioi", 9: "rti", 10: "crc", 11: "osix"}),
+
+    InstructionGroup.BRANCHES: InstructionDecoder({0: "beq", 1: "bne", 2: "bhs", 3: "blo", 4: "bmi", 5: "bpl",
+                                                   6: "bvs", 7: "bvc", 8: "bhi", 9: "bls", 10: "bge", 11: "blt",
+                                                   12: "bgt", 13: "ble", 14: "br", 15: "nop"})
+
+}
+
+registers = {
+    0: "r0",
+    1: "r1",
+    2: "r2",
+    3: "r3"
+}

--- a/cocodump/targets/cdm8/decoder.py
+++ b/cocodump/targets/cdm8/decoder.py
@@ -98,7 +98,7 @@ def decode_inst(instruction: int) -> tuple[Instruction, InstructionGroup | int]:
     return decoded_inst, high_nibble
 
 
-def decode(image: bytearray) -> DecodedSection:
+def decode(image: bytearray, has_ivt: bool = False) -> DecodedSection:
     section = DecodedSection()
 
     section_iter = iter(image)

--- a/cocodump/targets/cdm8/decoder.py
+++ b/cocodump/targets/cdm8/decoder.py
@@ -123,15 +123,12 @@ def decode(image: bytearray) -> DecodedSection:
 
                 current_addr += 1
 
-                # TODO: Refactor
+                inst.args.append(hex(byte))
+
                 if inst_gr == InstructionGroup.BRANCHES or \
                         inst.inst in ["jsr"]:
                     inst: BranchInstruction
-
                     inst.br_addr = byte
-                    inst.args.append(hex(byte))
-                else:
-                    inst.args.append(hex(byte))
 
             section.add_inst(inst)
 

--- a/cocodump/targets/cdm8/decoder.py
+++ b/cocodump/targets/cdm8/decoder.py
@@ -1,0 +1,141 @@
+from cocodump.base_types import BranchInstruction, DecodedSection, Instruction
+from cocodump.targets.cdm8.asm import InstructionGroup, inst_decoders, registers
+
+
+def decode_inst(instruction: int) -> tuple[Instruction, InstructionGroup | int]:
+    high_nibble = (instruction >> 4) & 0b1111
+    low_nibble = instruction & 0b1111
+
+    rd = instruction & 0b11
+    rs = (instruction >> 2) & 0b11
+
+    decoded_inst: Instruction | None = None
+
+    if instruction < 0x80:
+        return (
+            Instruction(
+                inst_decoders[InstructionGroup.DIRECT].get_instruction(high_nibble),
+                [
+                    registers[rs],
+                    registers[rd]
+                ]
+            ),
+            InstructionGroup.DIRECT
+        )
+
+    match high_nibble:
+        case InstructionGroup.UNARY_ARITH | InstructionGroup.SHIFTS:
+            decoded_inst = Instruction(
+                inst_decoders[high_nibble].get_instruction(rs),
+                [registers[rd]]
+            )
+
+        case InstructionGroup.ST:
+            decoded_inst = Instruction(
+                "st",
+                [
+                    registers[rs],
+                    registers[rd]
+                ]
+            )
+
+        case InstructionGroup.LD:
+            decoded_inst = Instruction(
+                "ld",
+                [
+                    registers[rs],
+                    registers[rd]
+                ]
+            )
+
+        case InstructionGroup.PUSH_GR:
+            if rs == 3:
+                decoded_inst = Instruction(
+                    inst_decoders[InstructionGroup.SP_GROUP].get_instruction(rd),
+                    []
+                )
+            else:
+                decoded_inst = Instruction(
+                    inst_decoders[high_nibble].get_instruction(rs),
+                    [registers[rd]]
+                )
+
+        case InstructionGroup.LDI_GR:
+            if rs == 0:
+                decoded_inst = Instruction(
+                    "ldi",
+                    [registers[rd]]
+                )
+            else:
+                inst = inst_decoders[high_nibble].get_instruction(low_nibble)
+
+                if inst == "jsr":
+                    decoded_inst = BranchInstruction(
+                        inst,
+                        []
+                    )
+                else:
+                    decoded_inst = Instruction(
+                        inst,
+                        []
+                    )
+
+        case InstructionGroup.BRANCHES:
+            decoded_inst = BranchInstruction(
+                inst_decoders[high_nibble].get_instruction(low_nibble),
+                []
+            )
+
+        case InstructionGroup.LDC:
+            decoded_inst = Instruction(
+                "ldc",
+                [
+                    registers[rs],
+                    registers[rd]
+                ]
+            )
+
+    return decoded_inst, high_nibble
+
+
+def decode(image: bytearray) -> DecodedSection:
+    section = DecodedSection()
+
+    section_iter = iter(image)
+    current_addr = 0
+
+    while True:
+        try:
+            byte = next(section_iter)
+
+            (inst, inst_gr) = decode_inst(byte)
+
+            inst.addr = current_addr
+            inst.inst_bytes = [byte]
+
+            current_addr += 1
+
+            if inst_gr == InstructionGroup.BRANCHES or \
+                    inst.inst in ["ldsa", "addsp", "setsp", "ldi", "jsr", "osix"]:
+                byte = next(section_iter)
+
+                inst.inst_bytes.append(byte)
+
+                current_addr += 1
+
+                # TODO: Refactor
+                if inst_gr == InstructionGroup.BRANCHES or \
+                        inst.inst in ["jsr"]:
+                    inst: BranchInstruction
+
+                    inst.br_addr = byte
+                    inst.args.append(hex(byte))
+                else:
+                    inst.args.append(hex(byte))
+
+            section.add_inst(inst)
+
+        except StopIteration:
+            break
+
+    return section

--- a/cocodump/targets/cdm8/reference_programs/all_inst.asm
+++ b/cocodump/targets/cdm8/reference_programs/all_inst.asm
@@ -1,0 +1,54 @@
+asect 0
+
+    move r1, r2
+    add r2, r3
+    addc r2, r1
+    sub r0, r1
+
+label:
+    and r0, r2
+    or r2, r3
+    xor r3, r0
+    cmp r2, r3
+
+    not r0
+    neg r1
+    dec r2
+    inc r3
+
+    shr r0
+    shla r1
+    shra r2
+    rol r3
+
+    st r0, r1
+    ld r2, r3
+
+    push r0
+    pop r1
+
+    ldsa r3, 115
+
+    addsp 101
+    setsp 87
+
+    pushall
+    popall
+
+    ldi r2, 135
+
+    halt
+    wait
+    jsr label
+    rts
+    ioi
+    rti
+    crc
+    osix 15
+
+    br label
+
+    ldc r2, r3
+
+
+end.

--- a/cocodump/targets/cdm8e/decoder.py
+++ b/cocodump/targets/cdm8e/decoder.py
@@ -1,0 +1,74 @@
+from cocodump.base_types import BranchInstruction, DecodedSection
+from cocodump.targets.cdm8.asm import InstructionGroup, inst_decoders
+from cocodump.targets.cdm8.decoder import decode_inst
+
+
+def normalize_imm8(val: int):
+    if val >= 0x80:
+        return (-1 << 8) | val
+    else:
+        return val
+
+
+def decode(image: bytearray) -> DecodedSection:
+    inst_decoders[InstructionGroup.LDI_GR].mnemonics[13] = "jmp"
+
+    section = DecodedSection()
+
+    section_iter = iter(image)
+    current_addr = 0
+
+    while True:
+        try:
+            byte = next(section_iter)
+
+            (inst, inst_gr) = decode_inst(byte)
+
+            if inst.inst == "jmp":
+                inst = BranchInstruction(
+                    "jmp",
+                    []
+                )
+
+            inst.addr = current_addr
+            inst.inst_bytes = [byte]
+
+            current_addr += 1
+
+            if inst.inst in ["jsr", "jmp"]:
+                lower_byte = next(section_iter)
+                higher_byte = next(section_iter)
+
+                inst.inst_bytes.append(lower_byte)
+                inst.inst_bytes.append(higher_byte)
+
+                word = (higher_byte << 8) | lower_byte
+
+                inst.br_addr = word
+                inst.args.append(hex(word))
+
+                current_addr += 2
+
+            if inst_gr == InstructionGroup.BRANCHES or \
+                    inst.inst in ["ldsa", "addsp", "setsp", "ldi", "osix"]:
+                byte = next(section_iter)
+
+                inst.inst_bytes.append(byte)
+
+                current_addr += 1
+
+                # TODO: Refactor
+                if inst_gr == InstructionGroup.BRANCHES:
+                    inst: BranchInstruction
+
+                    inst.br_addr = current_addr + normalize_imm8(byte) - 1
+                    inst.args.append(str(normalize_imm8(byte)) if byte >= 0x80 else '+' + str(byte))
+                else:
+                    inst.args.append(hex(byte))
+
+            section.add_inst(inst)
+
+        except StopIteration:
+            break
+
+    return section

--- a/cocodump/targets/cdm8e/decoder.py
+++ b/cocodump/targets/cdm8e/decoder.py
@@ -10,7 +10,7 @@ def normalize_imm8(val: int):
         return val
 
 
-def decode(image: bytearray) -> DecodedSection:
+def decode(image: bytearray, has_ivt: bool = False) -> DecodedSection:
     inst_decoders[InstructionGroup.LDI_GR].mnemonics[13] = "jmp"
 
     section = DecodedSection()

--- a/cocodump/targets/cdm8e/decoder.py
+++ b/cocodump/targets/cdm8e/decoder.py
@@ -57,7 +57,6 @@ def decode(image: bytearray) -> DecodedSection:
 
                 current_addr += 1
 
-                # TODO: Refactor
                 if inst_gr == InstructionGroup.BRANCHES:
                     inst: BranchInstruction
 

--- a/cocodump/targets/cdm8e/reference_programs/branches.asm
+++ b/cocodump/targets/cdm8e/reference_programs/branches.asm
@@ -1,0 +1,29 @@
+asect 0
+
+label_2:
+    ldi r0, 15
+
+    bhs 0x40
+
+    crc
+
+    goto vs, label
+
+    ldi r0, 25
+
+    jmp 0xab00
+
+    add r0, r1
+
+    br label_2
+
+asect 0xff00
+
+    ldi r0, 15
+
+label:
+    xor r3, r3
+
+    ldi r3, 25
+
+end.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,14 @@ authors = [
 
 packages = [
     { include = "cocas" },
-    { include = "synthm" }
+    { include = "synthm" },
+    { include = "cocodump" }
 ]
 
 [tool.poetry.scripts]
 cocas = 'cocas.main:main'
 synthm = 'synthm.main:main'
+cocodump = 'cocodump.main:main'
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
Implement universal disassembler for CdM processors named `cocodump`.

Currently, it is able to disassemble `.img` files. Support for other formats may be added in the future.

**Features:**
+ Automatic label placing for branch instructions
+ Folding repeated instructions
+ IVT decoding

**Supported processors:**
+ CdM-8
+ CdM-8e
+ CdM-16