### PR TITLE
Fix PC rollback with virtual instruction for CdM-16

### DIFF
--- a/logisim/cdm16/cdm16.circ
+++ b/logisim/cdm16/cdm16.circ
@@ -166,7 +166,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <circ-port height="10" pin="2240,720" width="10" x="205" y="165"/>
       <circ-port height="8" pin="2240,770" width="8" x="206" y="176"/>
       <circ-port height="8" pin="120,1380" width="8" x="106" y="186"/>
-      <circ-port height="10" pin="720,1700" width="10" x="135" y="195"/>
+      <circ-port height="10" pin="720,1700" width="10" x="85" y="115"/>
       <circ-anchor facing="north" height="6" width="6" x="147" y="137"/>
     </appear>
     <wire from="(1400,440)" to="(1400,460)"/>
@@ -1482,92 +1482,183 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(700,1330)" to="(710,1330)"/>
     <wire from="(610,1240)" to="(620,1240)"/>
     <wire from="(620,1250)" to="(630,1250)"/>
-    <comp lib="0" loc="(2050,1730)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="3"/>
-      <a name="label" val="phase"/>
+    <comp lib="0" loc="(1690,450)" name="Tunnel">
+      <a name="label" val="inc_address"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(340,1720)" name="Tunnel">
+    <comp lib="0" loc="(340,1810)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="fetch"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(350,1490)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(640,1770)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="CUT"/>
+      <a name="label" val="exc_triggered"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1810,810)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="0"/>
+    <comp lib="0" loc="(2160,810)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="inc_address"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="4" loc="(170,1770)" name="Counter">
-      <a name="width" val="3"/>
-      <a name="max" val="0x7"/>
+    <comp lib="0" loc="(2050,1730)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+    </comp>
+    <comp lib="6" loc="(446,1572)" name="Text">
+      <a name="text" val="2 - halted"/>
+    </comp>
+    <comp lib="1" loc="(2220,970)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(750,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1570,960)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(1360,1630)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(180,1660)" name="S-R Flip-Flop">
       <a name="trigger" val="falling"/>
     </comp>
-    <comp lib="0" loc="(120,1590)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
+    <comp lib="1" loc="(930,1710)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(450,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1450,490)" name="Tunnel">
+      <a name="label" val="pc_inc"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1060,610)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
+    <comp lib="3" loc="(2180,870)" name="Comparator">
+      <a name="width" val="28"/>
     </comp>
-    <comp lib="0" loc="(210,730)" name="Pin">
+    <comp lib="1" loc="(800,1220)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1590,600)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="cout"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(180,1580)" name="S-R Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1320,500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(620,1140)" name="OR Gate">
+      <a name="facing" val="west"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2690,1190)" name="Tunnel">
+      <a name="label" val="r_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1260,840)" name="Tunnel">
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(910,450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="rs0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(270,1500)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(1370,1420)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rs1_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2000,810)" name="Tunnel">
+      <a name="label" val="jsr"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1370,820)" name="Tunnel">
+      <a name="label" val="br_abs_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1710,1350)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1220,430)" name="Tunnel">
+      <a name="label" val="sp_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(130,700)" name="Pin">
       <a name="output" val="true"/>
       <a name="width" val="16"/>
-      <a name="label" val="R6"/>
+      <a name="label" val="R5"/>
     </comp>
-    <comp lib="0" loc="(1710,1290)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_rel_n"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(940,710)" name="Tunnel">
-      <a name="label" val="r_asrt1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1170,1030)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="X"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(990,1690)" name="Tunnel">
-      <a name="label" val="virtual_instruction"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(823,1119)" name="Text">
-      <a name="text" val="2. Multiple exceptions on the same phase"/>
-    </comp>
-    <comp lib="1" loc="(1640,730)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="2" loc="(2220,1490)" name="Multiplexer">
+    <comp lib="0" loc="(1970,500)" name="Pin">
       <a name="facing" val="west"/>
-      <a name="width" val="3"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="4" loc="(1000,1540)" name="Register">
+      <a name="output" val="true"/>
       <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
+      <a name="label" val="address"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(2690,1370)" name="Tunnel">
-      <a name="label" val="CUT"/>
+    <comp lib="0" loc="(770,1410)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="exc_triggered"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1160,1540)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="right"/>
-    </comp>
-    <comp lib="0" loc="(710,720)" name="Tunnel">
+    <comp lib="0" loc="(1860,1410)" name="Tunnel">
       <a name="facing" val="east"/>
+      <a name="label" val="alu3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2140,700)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="sign_extend"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1250,960)" name="Tunnel">
+      <a name="label" val="imm6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1900,1420)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2210,510)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="mem"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(220,610)" name="Tunnel">
       <a name="width" val="16"/>
-      <a name="label" val="r5"/>
+      <a name="label" val="r2"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1880,970)" name="Tunnel">
@@ -1576,546 +1667,95 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="label" val="op_type_d3"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(670,1600)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1360,1630)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1700,850)" name="Tunnel">
-      <a name="label" val="halt"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(600,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1140,1400)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_d1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1330)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_rel_nop"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2300,1650)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="imm6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(370,760)" name="Pull Resistor">
-      <a name="facing" val="east"/>
-    </comp>
-    <comp lib="3" loc="(1960,1610)" name="Shifter">
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1320,500)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(520,1210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1740,1020)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="1op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1880,890)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1690,1210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1050)" name="Tunnel">
-      <a name="label" val="pc_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(930,1820)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="virtual_instruction"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(450,1220)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="5" loc="(1830,540)" name="LED">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1120,1570)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2420,1610)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(810,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1680,1720)" name="Bit Extender">
-      <a name="in_width" val="6"/>
-      <a name="type" val="one"/>
-    </comp>
-    <comp lib="0" loc="(1130,1430)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="2"/>
-      <a name="label" val="XY"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(750,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1140,1400)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1000,400)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="label" val="bus0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(230,1160)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="direct_exc_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(831,1138)" name="Text">
-      <a name="text" val="3. Mutiple exceptions across several phases"/>
-    </comp>
-    <comp lib="0" loc="(210,550)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R0"/>
-    </comp>
-    <comp lib="3" loc="(1060,1510)" name="Comparator">
-      <a name="width" val="16"/>
-      <a name="mode" val="unsigned"/>
-    </comp>
-    <comp lib="6" loc="(2050,1766)" name="Text">
-      <a name="text" val="1, 3, 5, 7"/>
-    </comp>
-    <comp lib="1" loc="(2340,1120)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(1350,1630)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="1" loc="(1430,1150)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2150,920)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="28"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="0"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-    </comp>
-    <comp lib="0" loc="(2690,1290)" name="Tunnel">
-      <a name="label" val="sp_dec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1070)" name="Tunnel">
-      <a name="label" val="ps_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2270,1480)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rs0_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(930,1710)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(120,1650)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="critical_fault"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1510,920)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2000,830)" name="Tunnel">
-      <a name="label" val="rti"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1660,810)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1790,620)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="labelfont" val="SansSerif plain 16"/>
-    </comp>
-    <comp lib="0" loc="(340,820)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1890,840)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="0op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2420,1570)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(510,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(2230,1160)" name="ROM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="28"/>
-      <a name="contents">addr/data: 10 28
-4*8000400 4*c000000 4a00282 5280082 4a00282 5280082 4e00082 4280082
-4a01082 5280082 4a20082 5280082 c080580 4a00282 400000 20000
-1000 20000 200 20000 210001 5*8000400 8001 15*8000400
-c088482 8088482 8188482 c088480 8088480 8188480 c028482 8028482
-8*8000400 c0804ce c0804ee 808048e 80804ae 818048e 81804ae c0204ce
-c0204ee 802048e 80204ae 8000410 8000430 800a409 800a429 8008408
-8008428 4a01082 4080088 4a00092 4a000b2 8200449 8200469 4a00282
-4a00282 8*8000400 c098482 8098482 8198482 c098480 8098480 8198480
-c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
-8000569 8000400 c080180 8*0 8*8000400 4080180 5280082 9000400
-8800400 9000400 8000400 9000400 8800400 9000400 8800400 8000400
-20000 60*8000400 4a00282 4080088 9000400 9000400 8000400 8000400
-149 169 32*8000400 8*0 8*8000400 9000400 800000 9*8000400
-9000400 60*8000400 4080088 5*8000400 9000400 9000400 32*8000400 8*0
-9*8000400 8800400 70*8000400 4080088 39*8000400 8*0 80*8000400 1000000
-39*8000400 8*0 80*8000400 9000400 39*8000400 8*0 120*8000400 8*0
-120*8000400
-</a>
-    </comp>
     <comp lib="0" loc="(1740,1720)" name="Tunnel">
       <a name="label" val="imm_extend_negative"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(220,430)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="sp_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1860,1410)" name="Tunnel">
+    <comp lib="0" loc="(340,1720)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="alu3"/>
+      <a name="label" val="CUT"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1830,540)" name="Tunnel">
+    <comp lib="0" loc="(1170,1030)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
+      <a name="label" val="X"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(810,1320)" name="Tunnel">
-      <a name="label" val="exc_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(180,1420)" name="D Flip-Flop">
-      <a name="trigger" val="low"/>
-    </comp>
-    <comp lib="1" loc="(270,1500)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(1690,430)" name="Tunnel">
-      <a name="label" val="mem"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1740,1040)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="2op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1270,800)" name="Tunnel">
-      <a name="label" val="0op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1130)" name="Tunnel">
-      <a name="label" val="r_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(610,1240)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2110,1660)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(970,1810)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2350,1600)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1270)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_rel_p"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(890,1460)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="4" loc="(1000,1540)" name="Register">
       <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1660,540)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="shift_count_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+      <a name="trigger" val="falling"/>
     </comp>
     <comp lib="6" loc="(1282,702)" name="Text">
       <a name="text" val="2023"/>
       <a name="font" val="SansSerif bolditalic 16"/>
     </comp>
-    <comp lib="0" loc="(130,580)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R1"/>
-    </comp>
-    <comp lib="1" loc="(450,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1820,630)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="ps_flags"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1230,1200)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="4"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(200,1130)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(140,1110)" name="Pin">
+    <comp lib="4" loc="(220,1110)" name="Register">
       <a name="width" val="6"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="exc_vec"/>
-    </comp>
-    <comp lib="1" loc="(1370,1110)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(760,1210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="double_fault"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2210,900)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1370,820)" name="Tunnel">
-      <a name="label" val="br_abs_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(570,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2060,610)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="io_phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2210,510)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="mem"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(2260,1690)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2260,1690)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1350,1440)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1980,1420)" name="Constant">
-      <a name="width" val="3"/>
-    </comp>
-    <comp lib="0" loc="(120,1570)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="halt"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1790,810)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(530,790)" name="Register">
-      <a name="width" val="16"/>
       <a name="trigger" val="falling"/>
     </comp>
-    <comp lib="0" loc="(150,1790)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
+    <comp lib="0" loc="(880,1500)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0x8200"/>
+    </comp>
+    <comp lib="0" loc="(2300,1180)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="startup"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1440,750)" name="Controlled Buffer">
+    <comp lib="0" loc="(2140,680)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="address_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(370,590)" name="Pull Resistor">
+      <a name="facing" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1000,750)" name="Tunnel">
       <a name="facing" val="south"/>
       <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(2690,870)" name="Tunnel">
-      <a name="label" val="fp_asrt0"/>
+      <a name="label" val="busD"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(690,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(360,990)" name="Tunnel">
+    <comp lib="0" loc="(1740,1100)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="r_asrtD"/>
+      <a name="label" val="imm9"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1260,900)" name="Tunnel">
-      <a name="label" val="alu3_ind"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(130,460)" name="Pin">
+    <comp lib="0" loc="(210,430)" name="Pin">
       <a name="output" val="true"/>
       <a name="width" val="16"/>
-      <a name="label" val="PC"/>
+      <a name="label" val="SP"/>
+    </comp>
+    <comp lib="0" loc="(210,610)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R2"/>
+    </comp>
+    <comp lib="0" loc="(1880,910)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(120,1440)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="pull" val="down"/>
       <a name="label" val="hold"/>
     </comp>
-    <comp lib="0" loc="(360,880)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="r_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="0" loc="(1140,1630)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(2210,810)" name="Tunnel">
-      <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1450,510)" name="NOT Gate">
-      <a name="facing" val="west"/>
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(1370,1570)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="br_abs_flags_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(640,1770)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1790,540)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="int_en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(620,1620)" name="Bit Extender">
-      <a name="in_width" val="3"/>
-    </comp>
-    <comp lib="0" loc="(2350,1560)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(390,1030)" name="AND Gate">
+    <comp lib="1" loc="(510,1030)" name="AND Gate">
       <a name="facing" val="south"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(1690,450)" name="Tunnel">
-      <a name="label" val="inc_address"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="1" loc="(720,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
     </comp>
     <comp lib="0" loc="(470,720)" name="Tunnel">
       <a name="facing" val="east"/>
@@ -2123,12 +1763,39 @@ c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
       <a name="label" val="r1"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(310,1500)" name="NOT Gate">
-      <a name="size" val="20"/>
+    <comp lib="0" loc="(2240,770)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="data_in"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(2000,1630)" name="Tunnel">
-      <a name="label" val="imm_shift"/>
+    <comp lib="0" loc="(1000,580)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="label" val="bus1"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1260,900)" name="Tunnel">
+      <a name="label" val="alu3_ind"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2280,890)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1530,1110)" name="Tunnel">
+      <a name="label" val="br_rel_nop"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1400,420)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(1390,990)" name="NOT Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="20"/>
     </comp>
     <comp lib="0" loc="(1350,1470)" name="Splitter">
       <a name="facing" val="west"/>
@@ -2136,198 +1803,37 @@ c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
       <a name="incoming" val="3"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(870,1430)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="latch_int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2210,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="data/ins'"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(530,1290)" name="Priority Encoder"/>
-    <comp lib="0" loc="(2230,970)" name="Tunnel">
-      <a name="label" val="exc_trig_pc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1650,960)" name="NOT Gate">
+    <comp lib="0" loc="(1860,670)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(840,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(2010,1030)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(970,1470)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="fetched_instruction"/>
+      <a name="label" val="int_en"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(810,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1550,500)" name="Tunnel">
+    <comp lib="0" loc="(1590,580)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="alu_func"/>
+      <a name="width" val="4"/>
+      <a name="label" val="CVZN"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(447,1560)" name="Text">
+      <a name="text" val="1 - waiting"/>
     </comp>
     <comp lib="1" loc="(2020,1710)" name="OR Gate">
       <a name="width" val="16"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(1130,510)" name="Tunnel">
+    <comp lib="0" loc="(2210,1490)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="sp_latch"/>
+      <a name="width" val="3"/>
+      <a name="label" val="rs0"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(150,1240)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="int_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp loc="(2180,750)" name="bus_control">
+      <a name="facing" val="north"/>
     </comp>
-    <comp lib="1" loc="(690,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(420,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1360,490)" name="Probe">
+    <comp lib="0" loc="(1160,490)" name="Probe">
       <a name="facing" val="south"/>
       <a name="radix" val="16"/>
-    </comp>
-    <comp lib="0" loc="(220,640)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="r3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1310)" name="Tunnel">
-      <a name="label" val="sp_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(220,490)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="ps_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1680,1680)" name="Bit Extender">
-      <a name="in_width" val="6"/>
-    </comp>
-    <comp lib="0" loc="(1880,870)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,890)" name="Tunnel">
-      <a name="label" val="imm_asrt1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1610,960)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(140,1070)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="EXC"/>
-    </comp>
-    <comp lib="6" loc="(446,1572)" name="Text">
-      <a name="text" val="2 - halted"/>
-    </comp>
-    <comp lib="1" loc="(270,1770)" name="NOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(930,1800)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_rel_nop"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1750,640)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="CVZN"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(380,1690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(220,1110)" name="Register">
-      <a name="width" val="6"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="1" loc="(1390,1080)" name="NOT Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(1660,520)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2010,1060)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(120,1690)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(1740,690)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="di"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1350,1500)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rd_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1350)" name="Tunnel">
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2100,620)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="6" loc="(635,1119)" name="Text">
-      <a name="text" val="1"/>
-    </comp>
-    <comp lib="1" loc="(540,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1130,1630)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1580,420)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="arith_carry"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(120,1380)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="clock"/>
     </comp>
     <comp lib="0" loc="(1600,580)" name="Splitter">
       <a name="facing" val="south"/>
@@ -2339,280 +1845,39 @@ c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
       <a name="bit2" val="none"/>
       <a name="bit3" val="0"/>
     </comp>
-    <comp lib="0" loc="(2690,1010)" name="Tunnel">
-      <a name="label" val="pc_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(980,1690)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(950,1550)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,850)" name="Tunnel">
-      <a name="label" val="data"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1880,990)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(2520,1780)" name="Multiplexer">
+    <comp lib="2" loc="(1150,830)" name="Demultiplexer">
       <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
+      <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1070,430)" name="Tunnel">
-      <a name="label" val="fp_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="0" loc="(620,1490)" name="Bit Extender">
+      <a name="in_width" val="3"/>
     </comp>
-    <comp lib="0" loc="(2410,1800)" name="Tunnel">
+    <comp lib="0" loc="(1880,890)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_d0"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d1"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2010,1130)" name="Tunnel">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(1710,1270)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_rel_p"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(690,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(570,1140)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(190,1760)" name="Tunnel">
+      <a name="facing" val="south"/>
       <a name="width" val="3"/>
       <a name="label" val="phase"/>
       <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1200,930)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="XY"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(630,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2300,1220)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2040,1440)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(590,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="r3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1880,950)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(570,1450)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x7"/>
-    </comp>
-    <comp lib="3" loc="(1930,1700)" name="Shifter">
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(210,1810)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(430,1460)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(1650,900)" name="Decoder">
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(970,1570)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2300,1040)" name="Tunnel">
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2140,620)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(610,1720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="irq"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1140,1430)" name="Splitter">
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1700,890)" name="Tunnel">
-      <a name="label" val="ei"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1410,1110)" name="Tunnel">
-      <a name="label" val="br_rel_n"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(530,1150)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2130,860)" name="Constant">
-      <a name="width" val="28"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp loc="(1580,500)" name="alu"/>
-    <comp lib="0" loc="(2150,950)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-    </comp>
-    <comp lib="0" loc="(2690,1330)" name="Tunnel">
-      <a name="label" val="sp_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1220,460)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="sp_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(220,580)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="r1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1180,900)" name="Demultiplexer">
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(220,670)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="r4"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1350)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1430,970)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(1900,730)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="control" val="left"/>
-    </comp>
-    <comp lib="0" loc="(660,1130)" name="Tunnel">
-      <a name="label" val="rti"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2120,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="read"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,490)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="PS"/>
-    </comp>
-    <comp lib="0" loc="(1740,1000)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="0op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1350,1350)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-    </comp>
-    <comp lib="0" loc="(130,760)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="FP"/>
-    </comp>
-    <comp lib="6" loc="(1360,512)" name="Text">
-      <a name="text" val="PС"/>
-      <a name="font" val="SansSerif bold 20"/>
-    </comp>
-    <comp lib="0" loc="(1740,1740)" name="Tunnel">
-      <a name="label" val="imm6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(230,1520)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1560,980)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="0op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(2010,1590)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(120,1670)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1090)" name="Tunnel">
-      <a name="label" val="ps_latch_flags"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1880,910)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(830,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp loc="(1360,500)" name="pc_register">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(2210,680)" name="Tunnel">
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1140,1630)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(2150,980)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -2647,250 +1912,289 @@ c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
       <a name="bit26" val="none"/>
       <a name="bit27" val="none"/>
     </comp>
-    <comp lib="0" loc="(1410,1020)" name="Tunnel">
-      <a name="label" val="br_abs"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(880,1500)" name="Constant">
+    <comp lib="1" loc="(840,1470)" name="OR Gate">
       <a name="width" val="16"/>
-      <a name="value" val="0x8200"/>
-    </comp>
-    <comp lib="1" loc="(320,1800)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="1" loc="(940,1610)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="6" loc="(1278,659)" name="Text">
-      <a name="text" val="Coco-de-Mer 16"/>
-      <a name="font" val="SansSerif bolditalic 28"/>
-    </comp>
-    <comp lib="0" loc="(600,1210)" name="Tunnel">
-      <a name="label" val="latch_double_fault"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1700,870)" name="Tunnel">
-      <a name="label" val="wait"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(3970,2520)" name="Ground"/>
-    <comp lib="0" loc="(2690,1190)" name="Tunnel">
-      <a name="label" val="r_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1160,1470)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="X"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1620,800)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="imm9"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(660,1630)" name="Tunnel">
-      <a name="label" val="latch_double_fault"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(770,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="r6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1160,1540)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-    </comp>
-    <comp lib="0" loc="(660,1150)" name="Tunnel">
-      <a name="label" val="int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(800,1480)" name="Constant">
-      <a name="width" val="16"/>
-      <a name="value" val="0x8000"/>
-    </comp>
-    <comp lib="1" loc="(720,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1560,910)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1280,1330)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="fanout" val="9"/>
-      <a name="incoming" val="9"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1900,1480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(720,1400)" name="Bit Extender">
-      <a name="in_width" val="6"/>
-    </comp>
-    <comp lib="2" loc="(2450,1790)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(340,1560)" name="Priority Encoder">
-      <a name="select" val="2"/>
-    </comp>
-    <comp lib="6" loc="(551,1117)" name="Text">
-      <a name="text" val="3"/>
-    </comp>
-    <comp lib="0" loc="(1440,720)" name="Tunnel">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(1220,460)" name="Tunnel">
       <a name="width" val="16"/>
       <a name="label" val="sp_value"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(450,1710)" name="Tunnel">
-      <a name="label" val="startup"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1280,1320)" name="Tunnel">
+    <comp lib="0" loc="(2460,1560)" name="Tunnel">
       <a name="facing" val="south"/>
-      <a name="width" val="9"/>
-      <a name="label" val="imm9_d"/>
+      <a name="label" val="arith_carry"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1200,420)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1060,450)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-      <a name="label" val="fp"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1150,520)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1000,750)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="label" val="busD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(700,1320)" name="Tunnel">
+    <comp lib="0" loc="(1130,1430)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
+      <a name="width" val="2"/>
+      <a name="label" val="XY"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2210,550)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="rd/wr'"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1590,600)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="cout"/>
+    <comp lib="0" loc="(1420,430)" name="Tunnel">
+      <a name="label" val="pc_asrt0"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1370,1420)" name="Tunnel">
+    <comp lib="0" loc="(2690,1010)" name="Tunnel">
+      <a name="label" val="pc_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(940,1610)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(1660,520)" name="Tunnel">
       <a name="width" val="3"/>
-      <a name="label" val="rs1_d"/>
+      <a name="label" val="alu_op_type"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1580,1610)" name="Tunnel">
+    <comp lib="1" loc="(1430,1060)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1070,430)" name="Tunnel">
+      <a name="label" val="fp_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(2410,1720)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1540,820)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="1"/>
+      <a name="bit3" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1320,520)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="width" val="9"/>
-      <a name="label" val="imm9_d"/>
+      <a name="label" val="pc_latch"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="6" loc="(441,1585)" name="Text">
-      <a name="text" val="3 - fault"/>
-    </comp>
-    <comp lib="0" loc="(340,1810)" name="Pin">
-      <a name="facing" val="west"/>
+    <comp lib="0" loc="(210,670)" name="Pin">
       <a name="output" val="true"/>
-      <a name="label" val="fetch"/>
-      <a name="labelloc" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R4"/>
     </comp>
-    <comp lib="0" loc="(2190,550)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="read"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1750,1660)" name="Multiplexer">
-      <a name="select" val="2"/>
+    <comp lib="2" loc="(2010,1590)" name="Multiplexer">
       <a name="width" val="16"/>
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(570,1580)" name="Tunnel">
+    <comp lib="0" loc="(260,990)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="direct_exc_vec"/>
+      <a name="width" val="3"/>
+      <a name="label" val="rd"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2690,1270)" name="Tunnel">
-      <a name="label" val="sp_asrtD"/>
+    <comp lib="0" loc="(1690,430)" name="Tunnel">
+      <a name="label" val="mem"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(2360,1090)" name="Multiplexer">
-      <a name="width" val="28"/>
+    <comp lib="0" loc="(2000,830)" name="Tunnel">
+      <a name="label" val="rti"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1090)" name="Tunnel">
+      <a name="label" val="ps_latch_flags"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1390,560)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(980,1600)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1530,750)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(2690,950)" name="Tunnel">
+      <a name="label" val="imm_shift"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1080,960)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1080,670)" name="Tunnel">
+    <comp lib="2" loc="(2070,1690)" name="Multiplexer">
       <a name="width" val="16"/>
-      <a name="label" val="imm"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(220,610)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="r2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="0" loc="(1810,780)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
     </comp>
-    <comp lib="0" loc="(1190,1230)" name="Tunnel">
+    <comp lib="0" loc="(1350,570)" name="Tunnel">
       <a name="facing" val="east"/>
+      <a name="label" val="pc_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(120,1590)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1710,1170)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_abs"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(1790,670)" name="ps_register">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="6" loc="(1790,673)" name="Text">
+      <a name="text" val="PS"/>
+      <a name="font" val="SansSerif bold 20"/>
+    </comp>
+    <comp lib="0" loc="(1410,1110)" name="Tunnel">
+      <a name="label" val="br_rel_n"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(890,1720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="startup"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1920,650)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="ps_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(750,1310)" name="S-R Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="4" loc="(980,1690)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(920,1490)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="startup"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(590,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="r3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="3" loc="(1960,1610)" name="Shifter">
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(930,1820)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="virtual_instruction"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,900)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1820,630)" name="Tunnel">
       <a name="width" val="4"/>
       <a name="label" val="ps_flags"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(620,1140)" name="OR Gate">
-      <a name="facing" val="west"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1220,430)" name="Tunnel">
-      <a name="label" val="sp_asrt0"/>
+    <comp lib="0" loc="(2000,1630)" name="Tunnel">
+      <a name="label" val="imm_shift"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1530,1110)" name="Tunnel">
-      <a name="label" val="br_rel_nop"/>
+    <comp lib="0" loc="(1140,1590)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(2210,660)" name="Tunnel">
+      <a name="label" val="word"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(720,1760)" name="Tunnel">
-      <a name="label" val="latch_int"/>
+    <comp lib="0" loc="(440,1460)" name="Tunnel">
+      <a name="label" val="clk"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="6" loc="(450,1547)" name="Text">
-      <a name="text" val="0 - running"/>
-    </comp>
-    <comp lib="0" loc="(1440,970)" name="Tunnel">
-      <a name="label" val="br_abs_nop"/>
+    <comp lib="0" loc="(710,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="r5"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1060,420)" name="Controlled Buffer">
+    <comp lib="1" loc="(1060,610)" name="Controlled Buffer">
       <a name="facing" val="north"/>
       <a name="width" val="16"/>
     </comp>
-    <comp lib="1" loc="(2500,1650)" name="OR Gate">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(1740,1020)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="1op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2190,530)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="data"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(810,840)" name="AND Gate">
+      <a name="facing" val="north"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1850,490)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="label" val="address_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(760,1210)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="double_fault"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(150,1790)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1860,800)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(180,1500)" name="S-R Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1680,1720)" name="Bit Extender">
+      <a name="in_width" val="6"/>
+      <a name="type" val="one"/>
+    </comp>
+    <comp lib="1" loc="(2100,620)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1810,720)" name="Tunnel">
+      <a name="label" val="ps_latch_word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(360,1590)" name="Tunnel">
+      <a name="width" val="2"/>
+      <a name="label" val="status"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1690,1210)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(2690,990)" name="Tunnel">
       <a name="label" val="pc_asrt0"/>
@@ -2900,156 +2204,488 @@ c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
       <a name="width" val="3"/>
       <a name="value" val="0x6"/>
     </comp>
-    <comp lib="0" loc="(2320,1100)" name="Constant">
-      <a name="width" val="28"/>
-      <a name="value" val="0x8000000"/>
+    <comp lib="0" loc="(1730,1690)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(1810,720)" name="Tunnel">
-      <a name="label" val="ps_latch_word"/>
+    <comp lib="0" loc="(1350,1590)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1740,1000)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="0op"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(460,1140)" name="OR Gate">
+    <comp lib="0" loc="(2150,950)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+    </comp>
+    <comp lib="2" loc="(2220,1490)" name="Multiplexer">
+      <a name="facing" val="west"/>
+      <a name="width" val="3"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(410,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(120,1690)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(1710,1250)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1160,800)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="X"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1750,640)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="CVZN"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1680,1630)" name="Bit Extender">
+      <a name="in_width" val="9"/>
+      <a name="type" val="one"/>
+    </comp>
+    <comp lib="1" loc="(1430,1150)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp loc="(1360,500)" name="pc_register">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(140,1110)" name="Pin">
+      <a name="width" val="6"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="exc_vec"/>
+    </comp>
+    <comp lib="0" loc="(1260,1020)" name="Tunnel">
+      <a name="label" val="alu3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(650,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="r4"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2060,630)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(840,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1530,820)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(1160,500)" name="sp_register">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(830,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="fp"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1130,1630)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1350,1500)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rd_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(2230,1160)" name="ROM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="28"/>
+      <a name="contents">addr/data: 10 28
+4*8000400 4*c000000 4a00282 5280082 4a00282 5280082 4e00082 4280082
+4a01082 5280082 4a20082 5280082 c080580 4a00282 400000 20000
+1000 20000 200 20000 210001 5*8000400 8001 15*8000400
+c088482 8088482 8188482 c088480 8088480 8188480 c028482 8028482
+8*8000400 c0804ce c0804ee 808048e 80804ae 818048e 81804ae c0204ce
+c0204ee 802048e 80204ae 8000410 8000430 800a409 800a429 8008408
+8008428 4a01082 4080088 4a00092 4a000b2 8200449 8200469 4a00282
+4a00282 8*8000400 c098482 8098482 8198482 c098480 8098480 8198480
+c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
+8000569 8000400 c080180 8*0 8*8000400 4080180 5280082 9000400
+8800400 9000400 8000400 9000400 8800400 9000400 8800400 8000400
+20000 60*8000400 4a00282 4080088 9000400 9000400 8000400 8000400
+149 169 32*8000400 8*0 8*8000400 9000400 800000 9*8000400
+9000400 60*8000400 4080088 5*8000400 9000400 9000400 32*8000400 8*0
+9*8000400 8800400 70*8000400 4080088 39*8000400 8*0 80*8000400 1000000
+39*8000400 8*0 80*8000400 9000400 39*8000400 8*0 120*8000400 8*0
+120*8000400
+</a>
+    </comp>
+    <comp lib="0" loc="(1880,990)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1130,480)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="busD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1440,750)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="2" loc="(1840,1220)" name="Priority Encoder"/>
+    <comp lib="1" loc="(420,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(2390,1090)" name="Splitter">
+      <a name="fanout" val="28"/>
+      <a name="incoming" val="28"/>
+      <a name="appear" val="right"/>
+    </comp>
+    <comp lib="0" loc="(1700,890)" name="Tunnel">
+      <a name="label" val="ei"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(140,1070)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="EXC"/>
+    </comp>
+    <comp lib="1" loc="(1640,920)" name="AND Gate">
       <a name="facing" val="north"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(210,610)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R2"/>
-    </comp>
-    <comp lib="4" loc="(750,1310)" name="S-R Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(1260,840)" name="Tunnel">
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1790,490)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="label" val="busA"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1900,810)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(1350,1470)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rs0_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1880,1710)" name="Constant">
+    <comp lib="2" loc="(1230,1200)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
       <a name="width" val="4"/>
-      <a name="value" val="0x2"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(210,1770)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
+    <comp lib="3" loc="(620,1440)" name="Comparator">
+      <a name="width" val="3"/>
+      <a name="mode" val="unsigned"/>
     </comp>
-    <comp lib="0" loc="(2210,660)" name="Tunnel">
+    <comp lib="5" loc="(1880,540)" name="LED">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(360,1560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="2"/>
+      <a name="label" val="status"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(430,1460)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(660,1150)" name="Tunnel">
+      <a name="label" val="int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(220,670)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="r4"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(140,1200)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="IRQ"/>
+    </comp>
+    <comp lib="1" loc="(1520,1110)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2140,600)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="word"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(220,430)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="sp_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(570,1430)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="exc_internal_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(130,760)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="FP"/>
+    </comp>
+    <comp lib="2" loc="(530,1290)" name="Priority Encoder"/>
+    <comp lib="0" loc="(1740,1040)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="2op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2160,1640)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="imm"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1350,1350)" name="Tunnel">
+      <a name="width" val="6"/>
+      <a name="label" val="imm6_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2350,1580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1580,1700)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="imm6_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1430,740)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="sp_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1160,1540)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+    </comp>
+    <comp lib="0" loc="(870,1430)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="latch_int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(450,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(530,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="r2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(360,1450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,810)" name="Tunnel">
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2150,920)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="28"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="0"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+    </comp>
+    <comp lib="2" loc="(940,660)" name="Multiplexer">
+      <a name="select" val="3"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1370,1590)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(340,1560)" name="Priority Encoder">
+      <a name="select" val="2"/>
+    </comp>
+    <comp lib="1" loc="(780,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(2690,1290)" name="Tunnel">
+      <a name="label" val="sp_dec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(450,1547)" name="Text">
+      <a name="text" val="0 - running"/>
+    </comp>
+    <comp lib="0" loc="(120,1610)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(2690,850)" name="Tunnel">
+      <a name="label" val="data"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1810,810)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="0"/>
+    </comp>
+    <comp lib="5" loc="(1830,540)" name="LED">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="2" loc="(1840,1060)" name="Priority Encoder"/>
+    <comp lib="0" loc="(1920,720)" name="Tunnel">
+      <a name="label" val="ps_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(940,460)" name="Tunnel">
+      <a name="label" val="r_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1670,810)" name="Tunnel">
+      <a name="label" val="int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,930)" name="Tunnel">
+      <a name="label" val="imm_extend_negative"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1260,940)" name="Tunnel">
+      <a name="label" val="alu2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(670,1600)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(2410,1780)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_d1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1330)" name="Tunnel">
+      <a name="label" val="sp_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,610)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="word"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(520,1210)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(980,1810)" name="Tunnel">
+      <a name="label" val="pc_inc_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(610,1240)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(660,1820)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="fetch"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1910,1620)" name="Constant">
-      <a name="width" val="4"/>
+    <comp lib="0" loc="(2690,1310)" name="Tunnel">
+      <a name="label" val="sp_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(2220,930)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(1410,1200)" name="Tunnel">
+      <a name="label" val="br_rel_p"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1730,1200)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(1210,780)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Y"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1140,1590)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
+    <comp lib="0" loc="(610,1720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="irq"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,1770)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(670,1400)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="int_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="0" loc="(2130,860)" name="Constant">
+      <a name="width" val="28"/>
+      <a name="value" val="0x0"/>
     </comp>
-    <comp lib="0" loc="(2000,810)" name="Tunnel">
-      <a name="label" val="jsr"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="0" loc="(140,1770)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x0"/>
     </comp>
-    <comp lib="1" loc="(1520,1110)" name="OR Gate">
+    <comp lib="1" loc="(700,1810)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="2" loc="(1840,1060)" name="Priority Encoder"/>
-    <comp lib="0" loc="(930,1680)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2140,700)" name="Tunnel">
+    <comp lib="0" loc="(2350,1600)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="sign_extend"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2300,1160)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="0"/>
-    </comp>
-    <comp lib="1" loc="(1530,750)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="1" loc="(1400,420)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(220,700)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="r5"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(370,590)" name="Pull Resistor">
-      <a name="facing" val="east"/>
-    </comp>
-    <comp lib="0" loc="(940,460)" name="Tunnel">
-      <a name="label" val="r_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,830)" name="Tunnel">
-      <a name="label" val="alu_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(940,510)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="select" val="3"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(2210,830)" name="Tunnel">
-      <a name="label" val="io_phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2190,510)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="mem"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1880,540)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(890,1700)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="latch_int"/>
+      <a name="label" val="alu2"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(2140,680)" name="Splitter">
@@ -3072,337 +2708,148 @@ c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
       <a name="bit14" val="none"/>
       <a name="bit15" val="none"/>
     </comp>
-    <comp lib="2" loc="(1990,930)" name="Multiplexer">
-      <a name="select" val="3"/>
-      <a name="width" val="4"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1670,810)" name="Tunnel">
-      <a name="label" val="int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(470,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(1830,670)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(650,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="r4"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2340,1210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(1860,800)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(340,1790)" name="Tunnel">
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1370,1020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(570,1620)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="1" loc="(750,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1810,780)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-    </comp>
-    <comp lib="4" loc="(770,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(1140,1500)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(2690,1150)" name="Tunnel">
-      <a name="label" val="r_asrt1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2050,1060)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="10"/>
-      <a name="incoming" val="10"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(720,1810)" name="Tunnel">
-      <a name="label" val="reset_exc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(150,1200)" name="Tunnel">
-      <a name="label" val="irq"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(810,1290)" name="Tunnel">
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(640,1270)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1330,480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="busD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(1790,670)" name="ps_register">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="5" loc="(1880,540)" name="LED">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="6" loc="(754,1100)" name="Text">
-      <a name="text" val="Double fault: 1. Unrecoverable instruction"/>
-    </comp>
     <comp lib="0" loc="(2270,1400)" name="Tunnel">
       <a name="width" val="3"/>
       <a name="label" val="rs1_d"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(140,1770)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x0"/>
+    <comp lib="1" loc="(310,1500)" name="NOT Gate">
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(1370,1400)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_d0"/>
+    <comp lib="0" loc="(2690,1050)" name="Tunnel">
+      <a name="label" val="pc_latch"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(220,760)" name="Tunnel">
+    <comp lib="0" loc="(450,1710)" name="Tunnel">
+      <a name="label" val="startup"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1230)" name="Tunnel">
+      <a name="label" val="sign_extend"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2350,1620)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3_ind"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1580,1610)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="9"/>
+      <a name="label" val="imm9_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,890)" name="Tunnel">
+      <a name="label" val="imm_asrt1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,490)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="PS"/>
+    </comp>
+    <comp lib="0" loc="(1060,450)" name="Tunnel">
+      <a name="facing" val="north"/>
       <a name="width" val="16"/>
       <a name="label" val="fp"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2240,720)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="data_out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(940,660)" name="Multiplexer">
-      <a name="select" val="3"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(360,1590)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="status"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1080,620)" name="Tunnel">
-      <a name="label" val="imm_asrt1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(980,1810)" name="Tunnel">
-      <a name="label" val="pc_inc_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1630,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="6" loc="(635,1119)" name="Text">
+      <a name="text" val="1"/>
     </comp>
     <comp lib="0" loc="(1160,1450)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="Y"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(900,1600)" name="Tunnel">
+    <comp lib="0" loc="(1190,1230)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="ps_flags"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(620,1580)" name="Bit Extender">
+      <a name="in_width" val="6"/>
+    </comp>
+    <comp lib="0" loc="(1350,1440)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="1" loc="(1590,820)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(1160,1540)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="right"/>
+    </comp>
+    <comp lib="1" loc="(450,1220)" name="OR Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="1" loc="(700,1700)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1790,490)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="label" val="busA"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1640,730)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(120,1500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="wait"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1790,540)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="int_en"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,1810)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2300,1220)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="fetch"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(570,1140)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(420,1280)" name="Tunnel">
+    <comp lib="0" loc="(1770,720)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="exc_trig_pc"/>
+      <a name="label" val="ps_latch_flags"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1940,820)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(1210,780)" name="Tunnel">
+    <comp lib="0" loc="(2350,1560)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="Y"/>
+      <a name="label" val="shifts"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(1150,830)" name="Demultiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(2220,1410)" name="Multiplexer">
-      <a name="facing" val="west"/>
-      <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2300,1160)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="2"/>
-      <a name="label" val="status"/>
+    <comp lib="0" loc="(2690,1150)" name="Tunnel">
+      <a name="label" val="r_asrt1"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1710,1250)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3"/>
+    <comp lib="0" loc="(970,1470)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="fetched_instruction"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(420,1330)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_trig_ext"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(590,1200)" name="OR Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="2" loc="(1980,800)" name="Decoder">
-      <a name="selloc" val="tr"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(910,450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rs0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(890,1720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="startup"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2060,630)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(800,1290)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(1390,990)" name="NOT Gate">
-      <a name="facing" val="north"/>
+    <comp lib="1" loc="(1620,820)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(2210,610)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="word"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(770,1410)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(570,1250)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="0" loc="(2690,930)" name="Tunnel">
-      <a name="label" val="imm_extend_negative"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2140,680)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="address_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1430,740)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="sp_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1920,1100)" name="Bit Extender">
-      <a name="in_width" val="3"/>
-      <a name="out_width" val="4"/>
-    </comp>
-    <comp lib="0" loc="(1120,1590)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="br_rel_flags_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(2180,750)" name="bus_control">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(2690,970)" name="Tunnel">
-      <a name="label" val="mem"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1740,1080)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="imm6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1190,1190)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="br_rel_flags_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(280,1540)" name="Constant"/>
-    <comp lib="0" loc="(530,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="r2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1410,500)" name="AND Gate">
-      <a name="facing" val="west"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(1840,1220)" name="Priority Encoder"/>
-    <comp lib="0" loc="(1850,490)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="label" val="address_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1080,730)" name="Tunnel">
-      <a name="label" val="imm_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1530,720)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="label" val="pc_value"/>
+    <comp lib="0" loc="(720,1810)" name="Tunnel">
+      <a name="label" val="reset_exc"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1350,520)" name="Tunnel">
@@ -3410,436 +2857,46 @@ c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
       <a name="label" val="clk"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(450,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(780,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(220,490)" name="Tunnel">
       <a name="width" val="16"/>
+      <a name="label" val="ps_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(2360,1670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(2210,830)" name="Tunnel">
+      <a name="label" val="io_phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(2110,760)" name="Controlled Buffer">
-      <a name="facing" val="west"/>
-      <a name="width" val="16"/>
-      <a name="control" val="left"/>
+    <comp lib="6" loc="(501,1190)" name="Text">
+      <a name="text" val="2"/>
     </comp>
-    <comp lib="1" loc="(1640,920)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2190,1380)" name="Tunnel">
+    <comp lib="0" loc="(1130,510)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="alu3_ind"/>
+      <a name="label" val="sp_latch"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1420,430)" name="Tunnel">
-      <a name="label" val="pc_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(1260,1210)" name="branch_logic">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="1" loc="(840,1470)" name="OR Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1470,530)" name="Tunnel">
+    <comp lib="0" loc="(1160,1470)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="pc_inc_inhibit"/>
+      <a name="label" val="X"/>
       <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(1790,673)" name="Text">
-      <a name="text" val="PS"/>
-      <a name="font" val="SansSerif bold 20"/>
-    </comp>
-    <comp lib="0" loc="(420,1300)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_trig_invalid_inst"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1250,960)" name="Tunnel">
-      <a name="label" val="imm6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(570,1490)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="exc_internal_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(350,1490)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(90,1770)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="CUT"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2160,810)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="inc_address"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1160,490)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="16"/>
-    </comp>
-    <comp lib="0" loc="(2010,1110)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-    </comp>
-    <comp lib="3" loc="(2180,870)" name="Comparator">
-      <a name="width" val="28"/>
-    </comp>
-    <comp lib="0" loc="(1740,1100)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="imm9"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2460,1560)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="arith_carry"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1900,1450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1200,500)" name="Tunnel">
-      <a name="label" val="sp_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2210,1450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rd"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(660,1250)" name="Register">
-      <a name="width" val="3"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(2690,1230)" name="Tunnel">
-      <a name="label" val="sign_extend"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(360,1560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="2"/>
-      <a name="label" val="status"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(2230,1060)" name="ROM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="28"/>
-      <a name="contents">addr/data: 10 28
-4*0 4*c000000 4a00282 5280882 ca00282 d280882 ce00082 e280082
-ca01082 d284082 ca20082 d2c0082 c0c0580 4a00282 8440000 a020000
-8041000 8024000 8040200 8020800 a210001 5*0 804a001 15*0
-c0c8082 80c8082 81c8082 c0c8080 80c8080 81c8080 c028082 8028082
-8*0 c0c00ce c0c00ee 80c008e 80c00ae 81c008e 81c00ae c0200ce
-c0200ee 802008e 80200ae 8040010 8040030 804a009 804a029 800a008
-800a028 4a01082 4080888 ca00092 ca000b2 a200049 a200069 4a00282
-4a00282 8*0 c0d8082 80d8082 81d8082 c0d8080 80d8080 81d8080
-c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
-8000969 8000400 c080580 16*0 c080980 d284082 9*0 8020800
-60*0 4a00282 c084088 4*0 8000949 8000969 120*0 4080888
-127*0 c084088
-</a>
-    </comp>
-    <comp lib="1" loc="(800,1220)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(260,990)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rd"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1390,560)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(120,1530)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="irq"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(590,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(1710,1230)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3_ind"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1370,1200)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(2180,610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1740,1060)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="mem2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1260,880)" name="Tunnel">
-      <a name="label" val="2op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(480,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="1" loc="(1060,740)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="control" val="left"/>
-    </comp>
-    <comp lib="0" loc="(2300,1200)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="latch_int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_abs"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1110)" name="Tunnel">
-      <a name="label" val="ps_latch_word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(620,1490)" name="Bit Extender">
-      <a name="in_width" val="3"/>
-    </comp>
-    <comp lib="2" loc="(720,1520)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2350,1620)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3_ind"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(810,1220)" name="Tunnel">
-      <a name="label" val="critical_fault"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2530,1780)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="alu_func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(700,1810)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1160,800)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="X"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1210)" name="Tunnel">
-      <a name="label" val="read"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(130,1780)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="2" loc="(1080,960)" name="Decoder">
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1990,1450)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="6" loc="(1789,595)" name="Text">
-      <a name="text" val="CVZN"/>
-    </comp>
-    <comp lib="2" loc="(670,1510)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2690,910)" name="Tunnel">
-      <a name="label" val="imm_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(1160,512)" name="Text">
-      <a name="text" val="SP"/>
-      <a name="font" val="SansSerif bold 20"/>
-    </comp>
-    <comp lib="0" loc="(1260,1020)" name="Tunnel">
-      <a name="label" val="alu3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(570,1530)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="exc_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(610,1740)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="int_en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1170)" name="Tunnel">
-      <a name="label" val="r_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1450,490)" name="Tunnel">
-      <a name="label" val="pc_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2310,1690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(2210,1410)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rs1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1200,810)" name="Demultiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2350,1580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1260,940)" name="Tunnel">
-      <a name="label" val="alu2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(180,1580)" name="S-R Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
     <comp lib="1" loc="(700,1760)" name="OR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(1260,1000)" name="Tunnel">
-      <a name="label" val="mem3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2230,1370)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(1650,440)" name="AND Gate">
-      <a name="facing" val="west"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(960,1730)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(950,1840)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1420,460)" name="Tunnel">
+    <comp lib="0" loc="(1010,1500)" name="Constant">
       <a name="width" val="16"/>
-      <a name="label" val="pc_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+      <a name="value" val="0x8004"/>
     </comp>
-    <comp lib="0" loc="(1680,1590)" name="Bit Extender">
-      <a name="in_width" val="9"/>
-    </comp>
-    <comp lib="1" loc="(1760,1320)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(2410,1720)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(720,1700)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IAck"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1920,650)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="ps_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(2070,1690)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1970,500)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="address"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(1620,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(1600,570)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-    </comp>
-    <comp lib="2" loc="(940,1470)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="4" loc="(710,790)" name="Register">
+    <comp lib="4" loc="(650,790)" name="Register">
       <a name="width" val="16"/>
       <a name="trigger" val="falling"/>
     </comp>
-    <comp lib="1" loc="(1590,820)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(190,1760)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="3"/>
-      <a name="label" val="phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1370,1440)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="shift_count_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(390,1450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
+    <comp lib="0" loc="(3970,2520)" name="Ground"/>
     <comp lib="0" loc="(1860,650)" name="Splitter">
       <a name="facing" val="south"/>
       <a name="fanout" val="1"/>
@@ -3862,14 +2919,330 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="bit14" val="none"/>
       <a name="bit15" val="0"/>
     </comp>
-    <comp lib="0" loc="(1690,1190)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="shifts"/>
+    <comp lib="1" loc="(1990,1490)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="2" loc="(790,1440)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1370,1400)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_d0"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2160,1640)" name="Tunnel">
+    <comp lib="0" loc="(1250,980)" name="Tunnel">
+      <a name="label" val="imm9"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(480,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(1940,820)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="2" loc="(2310,1070)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="28"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1550,500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="alu_func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(380,1510)" name="Tunnel">
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,1760)" name="Tunnel">
+      <a name="label" val="latch_int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2110,1660)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(340,1700)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1350,1500)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(990,1690)" name="Tunnel">
+      <a name="label" val="virtual_instruction"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2340,1120)" name="OR Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(2050,1060)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="10"/>
+      <a name="incoming" val="10"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(720,1400)" name="Bit Extender">
+      <a name="in_width" val="6"/>
+    </comp>
+    <comp lib="6" loc="(754,1100)" name="Text">
+      <a name="text" val="Double fault: 1. Unrecoverable instruction"/>
+    </comp>
+    <comp lib="0" loc="(930,1800)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_rel_nop"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2240,900)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(810,1320)" name="Tunnel">
+      <a name="label" val="exc_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1680,1590)" name="Bit Extender">
+      <a name="in_width" val="9"/>
+    </comp>
+    <comp lib="1" loc="(2230,1370)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(2030,1440)" name="Multiplexer">
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1000,400)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="label" val="bus0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(823,1119)" name="Text">
+      <a name="text" val="2. Multiple exceptions on the same phase"/>
+    </comp>
+    <comp lib="0" loc="(1350,1350)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+    </comp>
+    <comp lib="0" loc="(1140,1500)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="1" loc="(800,1290)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2300,1200)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="latch_int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1370,1440)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="shift_count_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(2360,1090)" name="Multiplexer">
+      <a name="width" val="28"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(2230,1060)" name="ROM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="28"/>
+      <a name="contents">addr/data: 10 28
+4*0 4*c000000 4a00282 5280882 ca00282 d280882 ce00082 e280082
+ca01082 d284082 ca20082 d2c0082 c0c0580 4a00282 8440000 a020000
+8041000 8024000 8040200 8020800 a210001 5*0 804a001 15*0
+c0c8082 80c8082 81c8082 c0c8080 80c8080 81c8080 c028082 8028082
+8*0 c0c00ce c0c00ee 80c008e 80c00ae 81c008e 81c00ae c0200ce
+c0200ee 802008e 80200ae 8040010 8040030 804a009 804a029 800a008
+800a028 4a01082 4080888 ca00092 ca000b2 a200049 a200069 4a00282
+4a00282 8*0 c0d8082 80d8082 81d8082 c0d8080 80d8080 81d8080
+c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
+8000969 8000400 c080580 16*0 c080980 d284082 9*0 8020800
+60*0 4a00282 c084088 4*0 8000949 8000969 120*0 4080888
+127*0 c084088
+</a>
+    </comp>
+    <comp lib="6" loc="(2050,1766)" name="Text">
+      <a name="text" val="1, 3, 5, 7"/>
+    </comp>
+    <comp lib="0" loc="(130,580)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R1"/>
+    </comp>
+    <comp lib="0" loc="(2210,550)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="rd/wr'"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1710,1330)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_rel_nop"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(690,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2690,1270)" name="Tunnel">
+      <a name="label" val="sp_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(250,1810)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(190,1070)" name="Tunnel">
+      <a name="label" val="exc_trig_ext"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="3" loc="(1060,1510)" name="Comparator">
+      <a name="width" val="16"/>
+      <a name="mode" val="unsigned"/>
+    </comp>
+    <comp lib="0" loc="(220,640)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="r3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1150,520)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(620,1620)" name="Bit Extender">
+      <a name="in_width" val="3"/>
+    </comp>
+    <comp lib="0" loc="(1080,670)" name="Tunnel">
       <a name="width" val="16"/>
       <a name="label" val="imm"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1060,740)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="control" val="left"/>
+    </comp>
+    <comp lib="0" loc="(220,460)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="pc_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,530)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="data/ins'"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(1390,1080)" name="NOT Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(1390,1170)" name="NOT Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(890,1700)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="latch_int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(420,1280)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_trig_pc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,1410)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="rs1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(2220,1410)" name="Multiplexer">
+      <a name="facing" val="west"/>
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1830,540)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(1789,595)" name="Text">
+      <a name="text" val="CVZN"/>
+    </comp>
+    <comp lib="0" loc="(2260,1690)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="1"/>
+      <a name="bit3" val="2"/>
+    </comp>
+    <comp lib="6" loc="(1552,792)" name="Text">
+      <a name="text" val="int, reset"/>
+    </comp>
+    <comp lib="0" loc="(340,820)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2420,1610)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1370,1200)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(900,1600)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(270,1770)" name="NOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(570,1580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="direct_exc_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1740,690)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="di"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(220,550)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="r0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1200,520)" name="Tunnel">
+      <a name="label" val="sp_dec"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(220,730)" name="Tunnel">
@@ -3877,36 +3250,734 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="r6"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2270,1450)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rd_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="0" loc="(1680,1680)" name="Bit Extender">
+      <a name="in_width" val="6"/>
     </comp>
-    <comp lib="0" loc="(1350,1590)" name="Splitter">
+    <comp lib="1" loc="(1650,440)" name="AND Gate">
       <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="4" loc="(430,1690)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="2" loc="(2030,1440)" name="Multiplexer">
-      <a name="width" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="6" loc="(447,1560)" name="Text">
-      <a name="text" val="1 - waiting"/>
-    </comp>
-    <comp lib="1" loc="(1430,1060)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(360,990)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="r_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1370,1570)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="br_abs_flags_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(230,1110)" name="Tunnel">
+      <a name="width" val="6"/>
+      <a name="label" val="exc_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,910)" name="Tunnel">
+      <a name="label" val="imm_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(530,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="1" loc="(2340,1210)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(530,1150)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2120,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="read"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1060,420)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(230,1860)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="CUT"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1250)" name="Tunnel">
+      <a name="label" val="sp_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(810,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="6" loc="(551,1117)" name="Text">
+      <a name="text" val="3"/>
     </comp>
     <comp lib="0" loc="(410,720)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="width" val="16"/>
       <a name="label" val="r0"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1880,540)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2140,620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(940,710)" name="Tunnel">
+      <a name="label" val="r_asrt1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1350,1470)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rs0_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1580,420)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="arith_carry"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(810,1290)" name="Tunnel">
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1150,1010)" name="Demultiplexer">
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1890,840)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="0op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1990,1450)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="2" loc="(1590,450)" name="Multiplexer">
+      <a name="facing" val="west"/>
+      <a name="selloc" val="tr"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(460,1140)" name="OR Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2690,1110)" name="Tunnel">
+      <a name="label" val="ps_latch_word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2300,1040)" name="Tunnel">
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1880,1710)" name="Constant">
+      <a name="width" val="4"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="1" loc="(390,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(660,1250)" name="Register">
+      <a name="width" val="3"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="6" loc="(1282,680)" name="Text">
+      <a name="text" val="Designed by Nikolay Repin"/>
+      <a name="font" val="SansSerif bolditalic 16"/>
+    </comp>
+    <comp lib="0" loc="(2190,1360)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="1op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1710,1290)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_rel_n"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(910,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="rs1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,730)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R6"/>
+    </comp>
+    <comp lib="0" loc="(1140,1400)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(2230,970)" name="Tunnel">
+      <a name="label" val="exc_trig_pc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(120,1380)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="clock"/>
+    </comp>
+    <comp lib="0" loc="(570,1450)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x7"/>
+    </comp>
+    <comp lib="4" loc="(830,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(650,1690)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1980,800)" name="Decoder">
+      <a name="selloc" val="tr"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(140,1240)" name="Pin">
+      <a name="width" val="6"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="int_vec"/>
+    </comp>
+    <comp lib="0" loc="(210,550)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R0"/>
+    </comp>
+    <comp lib="0" loc="(130,640)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R3"/>
+    </comp>
+    <comp lib="0" loc="(570,1530)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="exc_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1370,1020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(2360,1670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(930,1680)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(120,1570)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="halt"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2010,1030)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="2" loc="(2520,1780)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1640,470)" name="Tunnel">
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2010,1130)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="3"/>
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(441,1585)" name="Text">
+      <a name="text" val="3 - fault"/>
+    </comp>
+    <comp lib="0" loc="(710,1550)" name="Tunnel">
+      <a name="label" val="exc_trig_ext"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1560,910)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1860,1430)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3_ind"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1880,950)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(150,1200)" name="Tunnel">
+      <a name="label" val="irq"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(270,980)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(600,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(1730,1200)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(2310,1690)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(2690,870)" name="Tunnel">
+      <a name="label" val="fp_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(970,1570)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1900,1450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(620,1530)" name="Bit Extender">
+      <a name="in_width" val="6"/>
+    </comp>
+    <comp lib="1" loc="(1660,810)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(590,1200)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(1740,1060)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="mem2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,1700)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IAck"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(750,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(570,1490)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="exc_internal_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1350)" name="Tunnel">
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(890,1460)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(180,1420)" name="D Flip-Flop">
+      <a name="trigger" val="low"/>
+    </comp>
+    <comp lib="0" loc="(1700,870)" name="Tunnel">
+      <a name="label" val="wait"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2270,1450)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rd_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2260,1690)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1180,900)" name="Demultiplexer">
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1440,970)" name="Tunnel">
+      <a name="label" val="br_abs_nop"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(655,1176)" name="Text">
+      <a name="text" val="int, reset, rti"/>
+    </comp>
+    <comp lib="0" loc="(2230,930)" name="Tunnel">
+      <a name="label" val="exc_trig_sp"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1280,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="9"/>
+      <a name="label" val="imm9_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(220,760)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="fp"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1630,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1600,570)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+    </comp>
+    <comp lib="0" loc="(2690,1370)" name="Tunnel">
+      <a name="label" val="CUT"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(640,1270)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1120,1590)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="br_rel_flags_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2180,610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1140,1400)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_d1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1740,1120)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="mem3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2300,1160)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="0"/>
+    </comp>
+    <comp lib="3" loc="(1930,1700)" name="Shifter">
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1700,910)" name="Tunnel">
+      <a name="label" val="di"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(220,580)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="r1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(1160,512)" name="Text">
+      <a name="text" val="SP"/>
+      <a name="font" val="SansSerif bold 20"/>
+    </comp>
+    <comp lib="0" loc="(1200,930)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="XY"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2190,1380)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3_ind"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(230,1520)" name="OR Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2010,1060)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(570,1250)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="0" loc="(2690,1130)" name="Tunnel">
+      <a name="label" val="r_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,680)" name="Tunnel">
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1530,720)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="label" val="pc_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2290,890)" name="Tunnel">
+      <a name="label" val="exc_trig_invalid_inst"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2060,610)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="io_phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(570,1620)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="4" loc="(590,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(2690,1030)" name="Tunnel">
+      <a name="label" val="pc_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1790,810)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(120,1670)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(420,1300)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_trig_invalid_inst"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1410,500)" name="AND Gate">
+      <a name="facing" val="west"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1350,550)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="jsr"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1250,860)" name="Tunnel">
+      <a name="label" val="1op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1650,990)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2270,1480)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rs0_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1430,970)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="6" loc="(1360,512)" name="Text">
+      <a name="text" val="PС"/>
+      <a name="font" val="SansSerif bold 20"/>
+    </comp>
+    <comp lib="4" loc="(430,1690)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1980,1720)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(200,1130)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(710,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(700,1320)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1750,1660)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(1900,810)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(370,760)" name="Pull Resistor">
+      <a name="facing" val="east"/>
+    </comp>
+    <comp lib="0" loc="(610,1740)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="int_en"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(2130,1640)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1260,920)" name="Tunnel">
+      <a name="label" val="mem2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2190,550)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="read"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(150,1240)" name="Tunnel">
+      <a name="width" val="6"/>
+      <a name="label" val="int_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1980,1420)" name="Constant">
+      <a name="width" val="3"/>
+    </comp>
+    <comp lib="0" loc="(2690,970)" name="Tunnel">
+      <a name="label" val="mem"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(660,1130)" name="Tunnel">
+      <a name="label" val="rti"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1740,1080)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="imm6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1450,510)" name="NOT Gate">
+      <a name="facing" val="west"/>
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(120,1530)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="irq"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1710,1310)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_abs_nop"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2410,1800)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_d0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1190,1190)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="br_rel_flags_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2500,1650)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1830,670)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(570,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1700,850)" name="Tunnel">
+      <a name="label" val="halt"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(950,1840)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1210,1170)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="br_abs_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1740,1740)" name="Tunnel">
+      <a name="label" val="imm6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2300,1160)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="2"/>
+      <a name="label" val="status"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(940,1470)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(420,1260)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_trig_sp"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(960,1730)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1650,900)" name="Decoder">
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
     </comp>
     <comp lib="0" loc="(1830,650)" name="Splitter">
       <a name="facing" val="south"/>
@@ -3930,187 +4001,41 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="bit14" val="none"/>
       <a name="bit15" val="none"/>
     </comp>
-    <comp lib="0" loc="(650,1690)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1030)" name="Tunnel">
-      <a name="label" val="pc_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(410,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(570,1430)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="exc_internal_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1740,1120)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="mem3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2190,1520)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="imm6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(1552,792)" name="Text">
-      <a name="text" val="int, reset"/>
-    </comp>
-    <comp lib="0" loc="(620,1580)" name="Bit Extender">
-      <a name="in_width" val="6"/>
-    </comp>
-    <comp lib="5" loc="(1790,540)" name="LED">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1710,1310)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_abs_nop"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(1282,680)" name="Text">
-      <a name="text" val="Designed by Nikolay Repin"/>
-      <a name="font" val="SansSerif bolditalic 16"/>
-    </comp>
-    <comp lib="0" loc="(2190,530)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="data"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(690,1340)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="reset_exc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(420,1260)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_trig_sp"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(920,1490)" name="Tunnel">
+    <comp lib="1" loc="(510,840)" name="AND Gate">
       <a name="facing" val="north"/>
-      <a name="label" val="startup"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(830,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="fp"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(650,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(360,1450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1080,1520)" name="Tunnel">
-      <a name="label" val="double_fault"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1520,740)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="pc_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2370,1710)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x5"/>
-    </comp>
-    <comp lib="0" loc="(670,1250)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="exc_internal_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(130,640)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R3"/>
-    </comp>
-    <comp lib="0" loc="(120,1610)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(230,1110)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="exc_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1130,480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="busD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(501,1190)" name="Text">
-      <a name="text" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2140,600)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,430)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="SP"/>
-    </comp>
-    <comp lib="0" loc="(710,1550)" name="Tunnel">
-      <a name="label" val="exc_trig_ext"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1540,820)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2210,1490)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rs0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(980,1600)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(2050,1730)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-    </comp>
-    <comp lib="4" loc="(180,1500)" name="S-R Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(1980,1720)" name="Constant">
+    <comp lib="0" loc="(220,700)" name="Tunnel">
       <a name="width" val="16"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="0" loc="(620,1530)" name="Bit Extender">
-      <a name="in_width" val="6"/>
-    </comp>
-    <comp lib="0" loc="(1190,1210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="br_abs_flags_d"/>
+      <a name="label" val="r5"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(1150,1010)" name="Demultiplexer">
-      <a name="disabled" val="0"/>
+    <comp lib="1" loc="(2110,760)" name="Controlled Buffer">
+      <a name="facing" val="west"/>
+      <a name="width" val="16"/>
+      <a name="control" val="left"/>
+    </comp>
+    <comp lib="0" loc="(370,410)" name="Pull Resistor">
+      <a name="facing" val="east"/>
+    </comp>
+    <comp lib="0" loc="(2320,1100)" name="Constant">
+      <a name="width" val="28"/>
+      <a name="value" val="0x8000000"/>
+    </comp>
+    <comp lib="0" loc="(1350,1630)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(2690,830)" name="Tunnel">
+      <a name="label" val="alu_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(670,1510)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="16"/>
       <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(1520,920)" name="Splitter">
@@ -4118,32 +4043,255 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="incoming" val="4"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(2390,1090)" name="Splitter">
-      <a name="fanout" val="28"/>
-      <a name="incoming" val="28"/>
-      <a name="appear" val="right"/>
+    <comp lib="0" loc="(2690,1210)" name="Tunnel">
+      <a name="label" val="read"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1990,1490)" name="OR Gate">
+    <comp lib="4" loc="(170,1770)" name="Counter">
+      <a name="width" val="3"/>
+      <a name="max" val="0x7"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="1" loc="(1610,960)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="3"/>
     </comp>
-    <comp lib="0" loc="(1350,550)" name="Tunnel">
+    <comp lib="0" loc="(1470,530)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="jsr"/>
+      <a name="label" val="pc_inc_inhibit"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1770,720)" name="Tunnel">
+    <comp lib="0" loc="(1120,1570)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="ps_latch_flags"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d3"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(220,550)" name="Tunnel">
+    <comp lib="0" loc="(1360,490)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="16"/>
+    </comp>
+    <comp lib="0" loc="(340,1790)" name="Tunnel">
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1910,1620)" name="Constant">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="1" loc="(1200,420)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
       <a name="width" val="16"/>
-      <a name="label" val="r0"/>
+    </comp>
+    <comp lib="0" loc="(2300,1650)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="imm6"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1410,1200)" name="Tunnel">
-      <a name="label" val="br_rel_p"/>
+    <comp lib="0" loc="(130,460)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="PC"/>
+    </comp>
+    <comp lib="1" loc="(1900,730)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="control" val="left"/>
+    </comp>
+    <comp lib="2" loc="(940,510)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="select" val="3"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1260,1000)" name="Tunnel">
+      <a name="label" val="mem3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1790,620)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="labelfont" val="SansSerif plain 16"/>
+    </comp>
+    <comp lib="0" loc="(770,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="r6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1080,730)" name="Tunnel">
+      <a name="label" val="imm_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1200,500)" name="Tunnel">
+      <a name="label" val="sp_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2240,720)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="data_out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="2" loc="(2450,1790)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1690,1190)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1990,930)" name="Multiplexer">
+      <a name="select" val="3"/>
+      <a name="width" val="4"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(120,1650)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="critical_fault"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1920,1100)" name="Bit Extender">
+      <a name="in_width" val="3"/>
+      <a name="out_width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(810,1220)" name="Tunnel">
+      <a name="label" val="critical_fault"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(390,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(600,1210)" name="Tunnel">
+      <a name="label" val="latch_double_fault"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2050,1730)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="3"/>
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1880,870)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(470,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(420,1330)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_trig_ext"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(970,1810)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp loc="(1580,500)" name="alu"/>
+    <comp lib="0" loc="(1270,800)" name="Tunnel">
+      <a name="label" val="0op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2190,1520)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="imm6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(950,1550)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1560,980)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="0op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1410,1020)" name="Tunnel">
+      <a name="label" val="br_abs"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(280,1540)" name="Constant"/>
+    <comp lib="2" loc="(1200,810)" name="Demultiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(2040,1440)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1190,1210)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="br_abs_flags_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1330,480)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="busD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(1260,1210)" name="branch_logic">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1260,880)" name="Tunnel">
+      <a name="label" val="2op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1760,1320)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(690,1340)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="reset_exc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(800,1480)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0x8000"/>
+    </comp>
+    <comp lib="1" loc="(130,1780)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(1710,1230)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3_ind"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2370,1710)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x5"/>
+    </comp>
+    <comp lib="0" loc="(1740,670)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ei"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1420,460)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="pc_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(650,1730)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2010,1110)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+    </comp>
+    <comp lib="0" loc="(2690,1070)" name="Tunnel">
+      <a name="label" val="ps_asrtD"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="1" loc="(630,1030)" name="AND Gate">
@@ -4151,17 +4299,106 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(1730,1690)" name="Splitter">
+    <comp lib="1" loc="(660,1050)" name="Controlled Buffer">
       <a name="facing" val="south"/>
-      <a name="appear" val="center"/>
+      <a name="width" val="16"/>
     </comp>
-    <comp lib="0" loc="(1250,860)" name="Tunnel">
-      <a name="label" val="1op"/>
+    <comp lib="0" loc="(2690,1170)" name="Tunnel">
+      <a name="label" val="r_asrtD"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1210,1170)" name="Tunnel">
+    <comp lib="0" loc="(230,1160)" name="Tunnel">
+      <a name="width" val="6"/>
+      <a name="label" val="direct_exc_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1080,620)" name="Tunnel">
+      <a name="label" val="imm_asrt1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="5" loc="(1790,540)" name="LED">
       <a name="facing" val="south"/>
-      <a name="label" val="br_abs_d"/>
+    </comp>
+    <comp lib="0" loc="(1660,540)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="shift_count_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(630,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1510,920)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(380,1690)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(660,1630)" name="Tunnel">
+      <a name="label" val="latch_double_fault"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1280,1330)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="fanout" val="9"/>
+      <a name="incoming" val="9"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="2" loc="(720,1520)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(2420,1570)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(390,1450)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="6" loc="(831,1138)" name="Text">
+      <a name="text" val="3. Mutiple exceptions across several phases"/>
+    </comp>
+    <comp lib="1" loc="(1370,1110)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(770,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="1" loc="(1650,960)" name="NOT Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(1080,1520)" name="Tunnel">
+      <a name="label" val="double_fault"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2190,510)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="mem"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1440,720)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="label" val="sp_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2530,1780)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="alu_func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(670,1400)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="int_vec"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1880,930)" name="Tunnel">
@@ -4170,302 +4407,65 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="op_type_d2"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2240,770)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="data_in"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1350,570)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="pc_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1250,980)" name="Tunnel">
-      <a name="label" val="imm9"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(140,1200)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="IRQ"/>
-    </comp>
-    <comp lib="0" loc="(1350,1350)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="imm6_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(380,1510)" name="Tunnel">
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(370,410)" name="Pull Resistor">
-      <a name="facing" val="east"/>
-    </comp>
-    <comp lib="0" loc="(2410,1780)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_d1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(2130,1640)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2290,890)" name="Tunnel">
-      <a name="label" val="exc_trig_invalid_inst"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(340,1700)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1650,990)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1350,1500)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(140,1240)" name="Pin">
-      <a name="width" val="6"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="int_vec"/>
-    </comp>
-    <comp lib="3" loc="(620,1440)" name="Comparator">
-      <a name="width" val="3"/>
-      <a name="mode" val="unsigned"/>
-    </comp>
     <comp lib="0" loc="(1790,720)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(650,1730)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1200,520)" name="Tunnel">
-      <a name="label" val="sp_dec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(1160,500)" name="sp_register">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(120,1500)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="wait"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1900,1420)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(250,1810)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="2" loc="(790,1440)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(1390,1170)" name="NOT Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(1010,1500)" name="Constant">
-      <a name="width" val="16"/>
-      <a name="value" val="0x8004"/>
-    </comp>
-    <comp lib="0" loc="(2300,1180)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="startup"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1000,580)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="label" val="bus1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1860,1430)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3_ind"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(655,1176)" name="Text">
-      <a name="text" val="int, reset, rti"/>
-    </comp>
-    <comp lib="0" loc="(1860,670)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="int_en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2240,900)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(230,1860)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="CUT"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1680,1630)" name="Bit Extender">
-      <a name="in_width" val="9"/>
-      <a name="type" val="one"/>
-    </comp>
-    <comp lib="0" loc="(1740,670)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ei"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1590,450)" name="Multiplexer">
-      <a name="facing" val="west"/>
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(220,460)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="pc_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(390,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1320,520)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="pc_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1580,1700)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="imm6_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1250)" name="Tunnel">
-      <a name="label" val="sp_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(510,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(190,1070)" name="Tunnel">
-      <a name="label" val="exc_trig_ext"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1370,1590)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1700,910)" name="Tunnel">
-      <a name="label" val="di"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,670)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R4"/>
-    </comp>
-    <comp lib="0" loc="(1920,720)" name="Tunnel">
-      <a name="label" val="ps_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1640,470)" name="Tunnel">
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,950)" name="Tunnel">
-      <a name="label" val="imm_shift"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(700,1700)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(180,1660)" name="S-R Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(440,1460)" name="Tunnel">
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2280,890)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(2310,1070)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="28"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(2220,970)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1530,820)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1260,920)" name="Tunnel">
-      <a name="label" val="mem2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2190,1360)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="1op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1590,580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="CVZN"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(570,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(270,980)" name="Decoder">
-      <a name="select" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(1570,960)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(130,700)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R5"/>
-    </comp>
-    <comp lib="0" loc="(2230,930)" name="Tunnel">
-      <a name="label" val="exc_trig_sp"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(910,720)" name="Tunnel">
+    <comp lib="0" loc="(2210,1450)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="width" val="3"/>
-      <a name="label" val="rs1"/>
+      <a name="label" val="rd"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(660,1050)" name="Controlled Buffer">
+    <comp lib="0" loc="(1520,740)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="pc_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(1278,659)" name="Text">
+      <a name="text" val="Coco-de-Mer 16"/>
+      <a name="font" val="SansSerif bolditalic 28"/>
+    </comp>
+    <comp lib="1" loc="(320,1800)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(670,1250)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="exc_internal_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(570,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1140,1430)" name="Splitter">
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(360,880)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="r_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1620,800)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="imm9"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2220,930)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(540,1050)" name="Controlled Buffer">
       <a name="facing" val="south"/>
       <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1900,1480)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
   </circuit>
   <circuit name="sp_register">
@@ -4517,6 +4517,23 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(540,540)" to="(550,540)"/>
     <wire from="(570,730)" to="(580,730)"/>
     <wire from="(530,740)" to="(540,740)"/>
+    <comp lib="0" loc="(600,600)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="Mon"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(300,740)" name="Tunnel">
+      <a name="label" val="+2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,740)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="+2"/>
+    </comp>
+    <comp loc="(650,500)" name="incdec2"/>
     <comp lib="0" loc="(750,520)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="-2"/>
@@ -4526,13 +4543,18 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="en"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(520,700)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="count"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="2" loc="(490,500)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(300,770)" name="Tunnel">
-      <a name="label" val="-2"/>
+    <comp lib="1" loc="(570,730)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(470,520)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="count"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(330,490)" name="Pin">
@@ -4540,61 +4562,25 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="tristate" val="false"/>
       <a name="label" val="In"/>
     </comp>
-    <comp lib="1" loc="(570,730)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(600,600)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="Mon"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(550,540)" name="Pin">
-      <a name="facing" val="west"/>
+    <comp lib="0" loc="(290,770)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="pull" val="down"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(490,500)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="4" loc="(550,500)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(510,540)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,740)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="+2"/>
+      <a name="label" val="-2"/>
     </comp>
     <comp lib="2" loc="(770,490)" name="Multiplexer">
       <a name="width" val="16"/>
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="1" loc="(500,710)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(460,700)" name="Tunnel">
+    <comp lib="0" loc="(460,720)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="+2"/>
+      <a name="label" val="-2"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(290,770)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="-2"/>
+    <comp lib="0" loc="(650,520)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="+2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(800,490)" name="Pin">
       <a name="facing" val="west"/>
@@ -4603,20 +4589,44 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="Out"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp loc="(650,500)" name="incdec2"/>
-    <comp lib="0" loc="(650,520)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="+2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="1" loc="(500,710)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(470,520)" name="Tunnel">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(520,700)" name="Tunnel">
+      <a name="facing" val="south"/>
       <a name="label" val="count"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(300,740)" name="Tunnel">
+    <comp lib="0" loc="(460,700)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="+2"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(510,540)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="en"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(550,500)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(300,770)" name="Tunnel">
+      <a name="label" val="-2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(530,740)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="up"/>
+      <a name="label" val="en"/>
+    </comp>
+    <comp lib="0" loc="(550,540)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(550,570)" name="Pin">
       <a name="facing" val="west"/>
@@ -4624,16 +4634,6 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="pull" val="down"/>
       <a name="label" val="clk"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(530,740)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="up"/>
-      <a name="label" val="en"/>
-    </comp>
-    <comp lib="0" loc="(460,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="-2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
   </circuit>
   <circuit name="pc_register">
@@ -4685,26 +4685,62 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(570,730)" to="(580,730)"/>
     <wire from="(530,740)" to="(540,740)"/>
     <wire from="(510,720)" to="(520,720)"/>
-    <comp lib="0" loc="(760,520)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="asrt_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(550,540)" name="Pin">
+    <comp lib="0" loc="(550,570)" name="Pin">
       <a name="facing" val="west"/>
       <a name="tristate" val="false"/>
       <a name="pull" val="down"/>
-      <a name="label" val="clr"/>
+      <a name="label" val="clk"/>
       <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(300,770)" name="Tunnel">
-      <a name="label" val="+2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(290,800)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="pull" val="down"/>
       <a name="label" val="asrt_inc"/>
+    </comp>
+    <comp lib="1" loc="(660,520)" name="NOT Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(290,830)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="inverse_inc"/>
+    </comp>
+    <comp lib="0" loc="(760,520)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="asrt_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(570,730)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp loc="(660,500)" name="incdec2"/>
+    <comp lib="0" loc="(610,590)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="Mon"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(520,700)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="count"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(530,740)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="up"/>
+      <a name="label" val="en"/>
+    </comp>
+    <comp lib="0" loc="(580,730)" name="Tunnel">
+      <a name="label" val="en"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(510,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="+2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(300,800)" name="Tunnel">
       <a name="label" val="asrt_inc"/>
@@ -4717,24 +4753,12 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="Out"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(610,590)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="output" val="true"/>
+    <comp lib="4" loc="(550,500)" name="Register">
       <a name="width" val="16"/>
-      <a name="label" val="Mon"/>
-      <a name="labelloc" val="east"/>
+      <a name="trigger" val="falling"/>
     </comp>
-    <comp lib="0" loc="(290,770)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
+    <comp lib="0" loc="(300,770)" name="Tunnel">
       <a name="label" val="+2"/>
-    </comp>
-    <comp lib="1" loc="(570,730)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(300,830)" name="Tunnel">
-      <a name="label" val="inverse_inc"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(330,490)" name="Pin">
@@ -4742,62 +4766,38 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="tristate" val="false"/>
       <a name="label" val="In"/>
     </comp>
-    <comp lib="0" loc="(520,700)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="count"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="2" loc="(780,490)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="1" loc="(660,520)" name="NOT Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(510,540)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(550,570)" name="Pin">
+    <comp lib="0" loc="(550,540)" name="Pin">
       <a name="facing" val="west"/>
       <a name="tristate" val="false"/>
       <a name="pull" val="down"/>
-      <a name="label" val="clk"/>
+      <a name="label" val="clr"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(290,830)" name="Pin">
+    <comp lib="0" loc="(300,830)" name="Tunnel">
+      <a name="label" val="inverse_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,770)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="pull" val="down"/>
-      <a name="label" val="inverse_inc"/>
+      <a name="label" val="+2"/>
     </comp>
     <comp lib="0" loc="(660,550)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="inverse_inc"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="4" loc="(550,500)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(580,730)" name="Tunnel">
+    <comp lib="0" loc="(510,540)" name="Tunnel">
+      <a name="facing" val="north"/>
       <a name="label" val="en"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="2" loc="(490,500)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(530,740)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="up"/>
-      <a name="label" val="en"/>
-    </comp>
-    <comp loc="(660,500)" name="incdec2"/>
-    <comp lib="0" loc="(510,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="+2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(780,490)" name="Multiplexer">
       <a name="width" val="16"/>
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
@@ -4878,16 +4878,17 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(370,540)" to="(370,590)"/>
     <wire from="(300,540)" to="(370,540)"/>
     <wire from="(490,410)" to="(490,530)"/>
-    <comp lib="0" loc="(640,320)" name="Pin">
+    <comp lib="0" loc="(580,400)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
-      <a name="width" val="4"/>
+      <a name="width" val="16"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="out_flags"/>
+      <a name="label" val="out"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(500,350)" name="Tunnel">
-      <a name="label" val="ei"/>
+    <comp lib="0" loc="(400,240)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="set_int_flag"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(300,560)" name="Pin">
@@ -4895,10 +4896,89 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="pull" val="down"/>
       <a name="label" val="di"/>
     </comp>
+    <comp lib="0" loc="(500,270)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="15"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+      <a name="bit15" val="none"/>
+    </comp>
+    <comp lib="0" loc="(370,590)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ei"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(360,320)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="word"/>
+    </comp>
+    <comp lib="1" loc="(480,530)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(500,350)" name="Tunnel">
+      <a name="label" val="ei"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(460,280)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="2" loc="(460,400)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(300,520)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="latch_flags"/>
+    </comp>
+    <comp lib="0" loc="(300,540)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="ei"/>
+    </comp>
+    <comp lib="2" loc="(380,210)" name="Multiplexer">
+      <a name="facing" val="west"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(500,50)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(460,110)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
     <comp lib="0" loc="(350,590)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="di"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(430,550)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(530,400)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(300,450)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="clk"/>
+    </comp>
+    <comp lib="0" loc="(300,500)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="latch_word"/>
     </comp>
     <comp lib="0" loc="(510,50)" name="Pin">
       <a name="facing" val="west"/>
@@ -4908,82 +4988,25 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="flags"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="4" loc="(530,400)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(360,320)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="word"/>
-    </comp>
-    <comp lib="0" loc="(500,270)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="15"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-      <a name="bit15" val="none"/>
-    </comp>
-    <comp lib="0" loc="(300,500)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="latch_word"/>
-    </comp>
-    <comp lib="0" loc="(460,280)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(300,520)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="latch_flags"/>
-    </comp>
     <comp lib="1" loc="(430,510)" name="OR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(370,590)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ei"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(400,240)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="set_int_flag"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(380,210)" name="Multiplexer">
-      <a name="facing" val="west"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(300,540)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="ei"/>
     </comp>
     <comp lib="0" loc="(620,320)" name="Bit Extender">
       <a name="in_width" val="16"/>
       <a name="out_width" val="4"/>
     </comp>
-    <comp lib="1" loc="(480,530)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(430,550)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(460,110)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
     <comp lib="0" loc="(450,560)" name="Tunnel">
       <a name="label" val="set_int_flag"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(640,320)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="out_flags"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(500,130)" name="Splitter">
       <a name="facing" val="west"/>
@@ -5007,29 +5030,6 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="bit14" val="10"/>
       <a name="bit15" val="11"/>
     </comp>
-    <comp lib="0" loc="(580,400)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(300,450)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="clk"/>
-    </comp>
-    <comp lib="2" loc="(460,400)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(500,50)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
   </circuit>
   <circuit name="incdec2">
     <a name="circuit" val="incdec2"/>
@@ -5052,24 +5052,20 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(360,390)" to="(540,390)"/>
     <wire from="(510,410)" to="(510,420)"/>
     <wire from="(580,400)" to="(670,400)"/>
-    <comp lib="0" loc="(440,410)" name="Constant">
+    <comp lib="3" loc="(580,400)" name="Adder">
       <a name="width" val="16"/>
-      <a name="value" val="0xfffe"/>
-    </comp>
-    <comp lib="0" loc="(460,460)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="up"/>
-      <a name="label" val="inc/dec'"/>
-      <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="0" loc="(440,430)" name="Constant">
-      <a name="width" val="16"/>
-      <a name="value" val="0x2"/>
     </comp>
     <comp lib="2" loc="(480,420)" name="Multiplexer">
       <a name="width" val="16"/>
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(440,410)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0xfffe"/>
+    </comp>
+    <comp lib="0" loc="(440,430)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0x2"/>
     </comp>
     <comp lib="0" loc="(670,400)" name="Pin">
       <a name="facing" val="west"/>
@@ -5078,13 +5074,17 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="out"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="0" loc="(460,460)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="up"/>
+      <a name="label" val="inc/dec'"/>
+      <a name="labelloc" val="south"/>
+    </comp>
     <comp lib="0" loc="(360,390)" name="Pin">
       <a name="width" val="16"/>
       <a name="tristate" val="false"/>
       <a name="label" val="in"/>
-    </comp>
-    <comp lib="3" loc="(580,400)" name="Adder">
-      <a name="width" val="16"/>
     </comp>
   </circuit>
   <circuit name="bus_control">
@@ -5182,89 +5182,63 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(580,470)" to="(590,470)"/>
     <wire from="(600,490)" to="(610,490)"/>
     <wire from="(310,730)" to="(380,730)"/>
-    <comp loc="(590,690)" name="2s_compliment"/>
+    <comp lib="0" loc="(200,150)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="odd_address"/>
+    </comp>
+    <comp lib="1" loc="(470,830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(620,460)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
     <comp lib="0" loc="(770,240)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="clk_inhibit"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(720,150)" name="Tunnel">
-      <a name="label" val="phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(200,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="word"/>
-    </comp>
-    <comp lib="0" loc="(560,170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="odd"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
     <comp lib="0" loc="(210,180)" name="Tunnel">
       <a name="label" val="word"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(650,680)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(640,750)" name="Tunnel">
-      <a name="label" val="phase"/>
+    <comp lib="0" loc="(630,650)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="sign_extend"/>
       <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(650,720)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(330,430)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="from_bus"/>
-    </comp>
-    <comp lib="0" loc="(560,190)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(200,220)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk_no_inhibit"/>
     </comp>
     <comp lib="1" loc="(600,180)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(600,820)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
+    <comp lib="0" loc="(680,670)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(560,470)" name="bytes_swap"/>
+    <comp lib="0" loc="(310,730)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="data_in"/>
+    </comp>
+    <comp lib="0" loc="(560,860)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(760,260)" name="Tunnel">
-      <a name="facing" val="east"/>
+    <comp lib="0" loc="(650,410)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(640,750)" name="Tunnel">
       <a name="label" val="phase"/>
       <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(200,150)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="odd_address"/>
-    </comp>
-    <comp lib="0" loc="(620,120)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(540,780)" name="Register">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="1" loc="(470,830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
     </comp>
     <comp lib="2" loc="(700,700)" name="Multiplexer">
       <a name="selloc" val="tr"/>
@@ -5272,62 +5246,52 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(310,730)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="data_in"/>
-    </comp>
-    <comp lib="0" loc="(760,240)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(680,670)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(200,120)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="sign_extend"/>
-    </comp>
     <comp lib="4" loc="(670,120)" name="D Flip-Flop">
       <a name="trigger" val="falling"/>
     </comp>
-    <comp lib="0" loc="(560,860)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(710,700)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="to_bus"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(630,650)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="sign_extend"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(620,460)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
+    <comp lib="0" loc="(200,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="word"/>
     </comp>
     <comp lib="0" loc="(210,120)" name="Tunnel">
       <a name="label" val="sign_extend"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(610,490)" name="Tunnel">
-      <a name="label" val="phase"/>
+    <comp lib="0" loc="(420,820)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_inhibit"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(420,840)" name="Tunnel">
+    <comp lib="0" loc="(560,170)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
+      <a name="label" val="odd"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(600,820)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(330,430)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="from_bus"/>
+    </comp>
+    <comp lib="0" loc="(620,180)" name="Tunnel">
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(680,440)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="data_out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(760,260)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="phase"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(770,120)" name="Pin">
@@ -5336,10 +5300,26 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="inc_address"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(560,780)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
+    <comp lib="0" loc="(470,780)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="8"/>
+    </comp>
+    <comp lib="0" loc="(610,490)" name="Tunnel">
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(590,690)" name="2s_compliment"/>
+    <comp lib="0" loc="(200,220)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk_no_inhibit"/>
+    </comp>
+    <comp lib="0" loc="(210,150)" name="Tunnel">
+      <a name="label" val="odd"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,220)" name="Tunnel">
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(770,260)" name="Pin">
       <a name="facing" val="west"/>
@@ -5347,48 +5327,68 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="phase"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(210,220)" name="Tunnel">
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
     <comp loc="(580,410)" name="make_byte"/>
-    <comp loc="(590,670)" name="make_byte"/>
-    <comp lib="0" loc="(680,440)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="data_out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(620,180)" name="Tunnel">
-      <a name="label" val="clk_inhibit"/>
+    <comp lib="0" loc="(560,190)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="word"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(210,150)" name="Tunnel">
-      <a name="label" val="odd"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="4" loc="(540,780)" name="Register">
+      <a name="trigger" val="falling"/>
     </comp>
-    <comp lib="0" loc="(420,820)" name="Tunnel">
+    <comp lib="0" loc="(760,240)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="clk_inhibit"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(470,780)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="8"/>
+    <comp lib="2" loc="(650,680)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(650,410)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="0" loc="(710,700)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="to_bus"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp loc="(560,470)" name="bytes_swap"/>
+    <comp lib="0" loc="(560,780)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
     <comp lib="2" loc="(670,440)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="16"/>
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
     </comp>
+    <comp lib="0" loc="(200,120)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="sign_extend"/>
+    </comp>
+    <comp lib="0" loc="(620,120)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,150)" name="Tunnel">
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(650,720)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(420,840)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(590,670)" name="make_byte"/>
   </circuit>
   <circuit name="alu">
     <a name="circuit" val="alu"/>
@@ -5663,89 +5663,12 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(1060,720)" to="(1080,720)"/>
     <wire from="(560,710)" to="(570,710)"/>
     <wire from="(620,1010)" to="(630,1010)"/>
-    <comp lib="0" loc="(980,90)" name="Tunnel">
-      <a name="label" val="sub"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,450)" name="Tunnel">
-      <a name="label" val="add"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,510)" name="Tunnel">
-      <a name="label" val="sbc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(240,300)" name="Tunnel">
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(190,170)" name="Pin">
-      <a name="width" val="3"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="func"/>
-    </comp>
-    <comp lib="0" loc="(810,40)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="sbc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1280,320)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="encoded_type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(940,70)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(190,650)" name="Decoder">
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(600,780)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="adder_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1120,910)" name="Multiplexer">
+    <comp lib="2" loc="(1120,730)" name="Multiplexer">
       <a name="select" val="2"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="1" loc="(570,510)" name="NOT Gate">
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1090,270)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="3op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,100)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="V"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(980,70)" name="Tunnel">
-      <a name="label" val="neg"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(670,670)" name="Tunnel">
-      <a name="label" val="adder_c"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(600,710)" name="Tunnel">
-      <a name="label" val="sbc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,120)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Z"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1010,920)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="adder_v"/>
+    <comp lib="0" loc="(290,570)" name="Tunnel">
+      <a name="label" val="not"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(630,990)" name="Tunnel">
@@ -5753,108 +5676,126 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="shifter_out"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1130,730)" name="Tunnel">
-      <a name="label" val="C"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1050,870)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="adder_v"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(570,840)" name="2s_compliment"/>
-    <comp lib="0" loc="(1090,390)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,430)" name="Tunnel">
-      <a name="label" val="bic"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(810,100)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="adc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1120,560)" name="Multiplexer">
-      <a name="select" val="2"/>
+    <comp lib="0" loc="(490,130)" name="Pin">
       <a name="width" val="16"/>
-      <a name="enable" val="false"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="B"/>
     </comp>
-    <comp lib="0" loc="(500,70)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="A"/>
+    <comp lib="0" loc="(170,870)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(1050,730)" name="Multiplexer">
-      <a name="enable" val="false"/>
+    <comp lib="1" loc="(580,810)" name="NOT Gate">
+      <a name="width" val="16"/>
     </comp>
     <comp lib="1" loc="(580,670)" name="OR Gate">
       <a name="facing" val="north"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="2" loc="(190,840)" name="Decoder">
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(670,650)" name="Tunnel">
-      <a name="label" val="adder_v"/>
+    <comp lib="0" loc="(670,610)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="adder_out"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1050,690)" name="Tunnel">
+    <comp lib="0" loc="(240,300)" name="Tunnel">
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(600,780)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="adder_c"/>
+      <a name="width" val="16"/>
+      <a name="label" val="adder_out"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1070,860)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="value" val="0x0"/>
+    <comp lib="0" loc="(1310,140)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="N"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="2" loc="(600,640)" name="Multiplexer">
+    <comp lib="2" loc="(740,430)" name="Multiplexer">
+      <a name="select" val="2"/>
       <a name="width" val="16"/>
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(610,380)" name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(290,800)" name="Tunnel">
+      <a name="label" val="rol"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1220,320)" name="Priority Encoder">
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(1010,720)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(170,850)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(240,260)" name="Tunnel">
+      <a name="label" val="3op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(600,970)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(980,90)" name="Tunnel">
+      <a name="label" val="sub"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,410)" name="Tunnel">
+      <a name="label" val="xor"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(980,70)" name="Tunnel">
+      <a name="label" val="neg"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1130,320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(290,510)" name="Tunnel">
+      <a name="label" val="sbc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1330,610)" name="Tunnel">
+      <a name="label" val="Z"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1030,750)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="neg"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(560,710)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="sub"/>
+    <comp lib="0" loc="(640,590)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="adder_carry"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1070,930)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(170,500)" name="Tunnel">
-      <a name="facing" val="east"/>
+    <comp lib="0" loc="(190,280)" name="Pin">
       <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="op_type"/>
     </comp>
-    <comp lib="0" loc="(1030,930)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="neg"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1250,320)" name="Pull Resistor">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1110,940)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="encoded_type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1130,280)" name="AND Gate">
+    <comp lib="1" loc="(1220,1710)" name="NOT Gate"/>
+    <comp lib="1" loc="(940,70)" name="OR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(580,810)" name="NOT Gate">
-      <a name="width" val="16"/>
     </comp>
     <comp lib="0" loc="(1030,300)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -5864,27 +5805,268 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="bit1" val="none"/>
       <a name="bit2" val="0"/>
     </comp>
-    <comp lib="0" loc="(290,490)" name="Tunnel">
+    <comp loc="(570,870)" name="make_byte"/>
+    <comp lib="1" loc="(960,150)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(190,170)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="func"/>
+    </comp>
+    <comp lib="2" loc="(190,650)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(290,390)" name="Tunnel">
+      <a name="label" val="or"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(560,710)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="sub"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(200,140)" name="Tunnel">
-      <a name="label" val="cin"/>
+    <comp lib="0" loc="(1110,940)" name="Tunnel">
+      <a name="width" val="2"/>
+      <a name="label" val="encoded_type"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(170,870)" name="Tunnel">
+    <comp lib="1" loc="(610,460)" name="XOR Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1330,640)" name="Tunnel">
+      <a name="label" val="N"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(170,500)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="width" val="3"/>
       <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1110,760)" name="Tunnel">
+      <a name="width" val="2"/>
+      <a name="label" val="encoded_type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,470)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="none"/>
+    </comp>
+    <comp lib="2" loc="(1120,910)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(290,820)" name="Tunnel">
+      <a name="label" val="ror"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(610,420)" name="OR Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1070,860)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp loc="(640,620)" name="adder16">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="2" loc="(600,640)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1070,760)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="shifter_c"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1130,910)" name="Tunnel">
       <a name="label" val="V"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(240,280)" name="Tunnel">
+    <comp lib="0" loc="(170,660)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="label" val="2op"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,470)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(810,100)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="adc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1310,80)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="C"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(810,70)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1010,920)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="adder_v"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(490,70)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="A"/>
+    </comp>
+    <comp lib="0" loc="(290,430)" name="Tunnel">
+      <a name="label" val="bic"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(810,40)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="sbc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,760)" name="Tunnel">
+      <a name="label" val="shr"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1050,550)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="adder_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(560,610)" name="NOT Gate">
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(290,370)" name="Tunnel">
+      <a name="label" val="and"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1050,690)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="adder_c"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(750,430)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="logic_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(630,1010)" name="Tunnel">
+      <a name="label" val="shifter_c"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(190,470)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(290,610)" name="Tunnel">
+      <a name="label" val="scl"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1280,320)" name="Tunnel">
+      <a name="width" val="2"/>
+      <a name="label" val="encoded_type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(470,470)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="B"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,740)" name="Tunnel">
+      <a name="label" val="shl"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1030,930)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="neg"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(200,140)" name="Tunnel">
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(170,480)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="3op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1210,520)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1050,530)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="logic_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(600,600)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(890,90)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(500,130)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="B"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(1300,610)" name="zero16"/>
+    <comp lib="2" loc="(1050,910)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(290,780)" name="Tunnel">
+      <a name="label" val="shra"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(660,860)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="none"/>
+    </comp>
+    <comp lib="0" loc="(1010,900)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(290,840)" name="Tunnel">
+      <a name="label" val="rcl"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,490)" name="Tunnel">
+      <a name="label" val="sub"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(570,510)" name="NOT Gate">
+      <a name="width" val="16"/>
+    </comp>
+    <comp loc="(600,1000)" name="barrel_shifter">
+      <a name="facing" val="north"/>
     </comp>
     <comp lib="0" loc="(1310,640)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -5907,113 +6089,16 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="bit14" val="none"/>
       <a name="bit15" val="0"/>
     </comp>
-    <comp lib="0" loc="(1010,900)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(960,160)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="adder_carry"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(640,620)" name="adder16">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(290,780)" name="Tunnel">
-      <a name="label" val="shra"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,570)" name="Tunnel">
-      <a name="label" val="not"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(850,130)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp loc="(600,1000)" name="barrel_shifter">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(170,660)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="2op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="N"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(630,1010)" name="Tunnel">
-      <a name="label" val="shifter_c"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1090,330)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="3op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(610,460)" name="XOR Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp loc="(1300,610)" name="zero16"/>
-    <comp lib="0" loc="(290,800)" name="Tunnel">
-      <a name="label" val="rol"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1030,300)" name="Tunnel">
-      <a name="facing" val="east"/>
+    <comp lib="1" loc="(2850,390)" name="NOT Gate"/>
+    <comp lib="0" loc="(210,1010)" name="Pin">
       <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="shift_count"/>
     </comp>
-    <comp lib="0" loc="(1070,680)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(690,820)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="unary_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(960,150)" name="OR Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(290,470)" name="Tunnel">
-      <a name="label" val="adc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1050,570)" name="Tunnel">
+    <comp lib="0" loc="(1310,100)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="unary_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(660,860)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(600,600)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(890,90)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(290,590)" name="Tunnel">
-      <a name="label" val="sxt"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,80)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="C"/>
+      <a name="label" val="V"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="2" loc="(680,820)" name="Multiplexer">
@@ -6021,149 +6106,29 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="width" val="16"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="1" loc="(610,420)" name="OR Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1050,550)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="adder_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(640,590)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="adder_carry"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(200,170)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(890,50)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1110,590)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="encoded_type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,390)" name="Tunnel">
-      <a name="label" val="or"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,610)" name="Tunnel">
-      <a name="label" val="scl"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1220,1710)" name="NOT Gate"/>
-    <comp lib="0" loc="(600,1030)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(560,650)" name="NOT Gate">
-      <a name="width" val="16"/>
-    </comp>
     <comp lib="0" loc="(190,140)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="pull" val="down"/>
       <a name="label" val="Cin"/>
     </comp>
-    <comp lib="0" loc="(490,70)" name="Pin">
+    <comp lib="0" loc="(670,670)" name="Tunnel">
+      <a name="label" val="adder_c"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1130,730)" name="Tunnel">
+      <a name="label" val="C"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,470)" name="Tunnel">
+      <a name="label" val="adc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1250,320)" name="Pull Resistor">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(500,70)" name="Tunnel">
       <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
       <a name="label" val="A"/>
-    </comp>
-    <comp lib="0" loc="(490,130)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="B"/>
-    </comp>
-    <comp lib="0" loc="(1070,760)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="shifter_c"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(170,680)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1050,530)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="logic_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(580,570)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="neg"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,410)" name="Tunnel">
-      <a name="label" val="xor"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,100)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="V"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(660,860)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="none"/>
-    </comp>
-    <comp lib="2" loc="(1220,320)" name="Priority Encoder">
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="2" loc="(190,470)" name="Decoder">
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(290,840)" name="Tunnel">
-      <a name="label" val="rcl"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(750,430)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="logic_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(720,470)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="none"/>
-    </comp>
-    <comp lib="0" loc="(170,850)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,140)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="N"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(170,480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="3op"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="1" loc="(610,500)" name="AND Gate">
@@ -6171,69 +6136,17 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="1" loc="(1130,320)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(1070,680)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
     </comp>
-    <comp lib="0" loc="(1310,80)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="C"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(740,430)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(470,470)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="B"/>
+    <comp lib="0" loc="(290,550)" name="Tunnel">
+      <a name="label" val="neg"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(210,1010)" name="Pin">
-      <a name="width" val="3"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="shift_count"/>
-    </comp>
-    <comp lib="1" loc="(560,610)" name="NOT Gate">
+    <comp lib="0" loc="(690,820)" name="Tunnel">
       <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1010,740)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="adder_c"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,860)" name="Tunnel">
-      <a name="label" val="rcr"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(470,450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="A"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1050,590)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="shifter_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1120,730)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(500,130)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="B"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1090,360)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="2op"/>
+      <a name="label" val="unary_out"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1250,560)" name="Pin">
@@ -6243,85 +6156,83 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="S"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="1" loc="(610,380)" name="AND Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(1050,910)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(290,740)" name="Tunnel">
-      <a name="label" val="shl"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(240,260)" name="Tunnel">
-      <a name="label" val="3op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,370)" name="Tunnel">
-      <a name="label" val="and"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,550)" name="Tunnel">
-      <a name="label" val="neg"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(600,970)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1010,720)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(810,70)" name="Tunnel">
+    <comp lib="0" loc="(1310,80)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="cin"/>
+      <a name="label" val="C"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(200,280)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
+    <comp lib="1" loc="(850,130)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(1310,140)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="N"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1310,120)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Z"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(570,840)" name="2s_compliment"/>
+    <comp lib="1" loc="(560,650)" name="NOT Gate">
+      <a name="width" val="16"/>
     </comp>
     <comp lib="1" loc="(1090,290)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp loc="(570,870)" name="make_byte"/>
-    <comp lib="0" loc="(190,280)" name="Pin">
-      <a name="width" val="3"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="op_type"/>
-    </comp>
-    <comp lib="0" loc="(1110,760)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="encoded_type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(720,470)" name="Tunnel">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(200,170)" name="Tunnel">
       <a name="width" val="3"/>
       <a name="label" val="func"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(290,820)" name="Tunnel">
-      <a name="label" val="ror"/>
+    <comp lib="0" loc="(290,450)" name="Tunnel">
+      <a name="label" val="add"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(2850,390)" name="NOT Gate"/>
-    <comp lib="0" loc="(1330,640)" name="Tunnel">
-      <a name="label" val="N"/>
+    <comp lib="2" loc="(1050,730)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(240,280)" name="Tunnel">
+      <a name="label" val="2op"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(290,760)" name="Tunnel">
-      <a name="label" val="shr"/>
+    <comp lib="0" loc="(1110,590)" name="Tunnel">
+      <a name="width" val="2"/>
+      <a name="label" val="encoded_type"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1330,610)" name="Tunnel">
-      <a name="label" val="Z"/>
+    <comp lib="0" loc="(1310,100)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="V"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1090,390)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="shifts"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1030,300)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1050,570)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="unary_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(580,570)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="neg"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(890,50)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(1310,120)" name="Pin">
       <a name="facing" val="west"/>
@@ -6329,13 +6240,102 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="Z"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(1210,520)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="16"/>
-    </comp>
-    <comp lib="0" loc="(670,610)" name="Tunnel">
+    <comp lib="2" loc="(1120,560)" name="Multiplexer">
+      <a name="select" val="2"/>
       <a name="width" val="16"/>
-      <a name="label" val="adder_out"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(470,450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="A"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(600,1030)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,590)" name="Tunnel">
+      <a name="label" val="sxt"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(960,160)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="adder_carry"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,860)" name="Tunnel">
+      <a name="label" val="rcr"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1090,360)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="2op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(190,840)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(1090,330)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="3op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1010,740)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="adder_c"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1070,930)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(200,280)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1050,870)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="adder_v"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(670,650)" name="Tunnel">
+      <a name="label" val="adder_v"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(660,860)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(600,710)" name="Tunnel">
+      <a name="label" val="sbc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1130,280)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1050,590)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="shifter_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1090,270)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="3op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(170,680)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
   </circuit>
@@ -6461,46 +6461,52 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(910,600)" to="(1040,600)"/>
     <wire from="(150,180)" to="(160,180)"/>
     <wire from="(610,1140)" to="(610,1330)"/>
-    <comp lib="0" loc="(760,1350)" name="Splitter">
-      <a name="fanout" val="1"/>
+    <comp lib="0" loc="(150,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="cin"/>
+    </comp>
+    <comp lib="0" loc="(660,1330)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+    </comp>
+    <comp lib="0" loc="(540,920)" name="Splitter">
+      <a name="fanout" val="16"/>
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="0"/>
     </comp>
-    <comp lib="6" loc="(659,890)" name="Text">
-      <a name="text" val="shra"/>
-      <a name="font" val="SansSerif bold 14"/>
+    <comp lib="0" loc="(1110,620)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="cout"/>
+      <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="6" loc="(682,1100)" name="Text">
-      <a name="text" val="rol"/>
-      <a name="font" val="SansSerif bold 14"/>
+    <comp lib="0" loc="(540,710)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
     </comp>
-    <comp lib="3" loc="(680,1510)" name="Shifter">
-      <a name="width" val="17"/>
-      <a name="shift" val="rl"/>
+    <comp lib="0" loc="(760,720)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
     </comp>
     <comp lib="3" loc="(680,710)" name="Shifter">
       <a name="width" val="17"/>
       <a name="shift" val="lr"/>
     </comp>
-    <comp lib="6" loc="(658,465)" name="Text">
-      <a name="text" val="shl"/>
-      <a name="font" val="SansSerif bold 14"/>
+    <comp lib="0" loc="(150,120)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="In"/>
+    </comp>
+    <comp lib="0" loc="(1070,440)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(760,1730)" name="Splitter">
       <a name="facing" val="west"/>
@@ -6508,95 +6514,15 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(620,1140)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="5"/>
-      <a name="appear" val="right"/>
-      <a name="bit4" val="none"/>
-    </comp>
-    <comp lib="0" loc="(580,1710)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(540,1500)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(150,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="cin"/>
-    </comp>
-    <comp lib="0" loc="(220,290)" name="Bit Extender">
-      <a name="in_width" val="3"/>
-      <a name="out_width" val="5"/>
-    </comp>
     <comp lib="0" loc="(560,1630)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="cin"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(160,230)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(580,1500)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(720,1510)" name="Splitter">
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="3" loc="(700,1320)" name="Shifter">
-      <a name="width" val="16"/>
-      <a name="shift" val="rr"/>
-    </comp>
-    <comp lib="0" loc="(160,180)" name="Tunnel">
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(720,1720)" name="Splitter">
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(540,710)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="6" loc="(660,1477)" name="Text">
-      <a name="text" val="rcl"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="0" loc="(230,340)" name="Constant">
-      <a name="width" val="5"/>
-    </comp>
     <comp lib="3" loc="(680,500)" name="Shifter">
       <a name="width" val="17"/>
     </comp>
-    <comp lib="0" loc="(150,290)" name="Pin">
-      <a name="width" val="3"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="distance"/>
-    </comp>
-    <comp lib="0" loc="(310,440)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(760,500)" name="Splitter">
-      <a name="facing" val="west"/>
+    <comp lib="0" loc="(540,490)" name="Splitter">
       <a name="fanout" val="16"/>
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
@@ -6607,15 +6533,10 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(540,920)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
+    <comp lib="0" loc="(720,710)" name="Splitter">
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(560,1580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(760,1160)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -6637,41 +6558,47 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="bit14" val="none"/>
       <a name="bit15" val="none"/>
     </comp>
-    <comp lib="3" loc="(680,920)" name="Shifter">
-      <a name="width" val="17"/>
-      <a name="shift" val="ar"/>
-    </comp>
-    <comp lib="0" loc="(720,920)" name="Splitter">
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
     <comp lib="0" loc="(580,490)" name="Splitter">
       <a name="facing" val="west"/>
       <a name="fanout" val="17"/>
       <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="3" loc="(680,1720)" name="Shifter">
-      <a name="width" val="17"/>
-      <a name="shift" val="rr"/>
-    </comp>
-    <comp lib="0" loc="(620,1330)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="5"/>
-      <a name="appear" val="right"/>
-      <a name="bit4" val="none"/>
+    <comp lib="0" loc="(720,1510)" name="Splitter">
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(160,120)" name="Tunnel">
       <a name="width" val="16"/>
       <a name="label" val="value"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(760,720)" name="Splitter">
+    <comp lib="3" loc="(700,1320)" name="Shifter">
+      <a name="width" val="16"/>
+      <a name="shift" val="rr"/>
+    </comp>
+    <comp lib="6" loc="(682,1100)" name="Text">
+      <a name="text" val="rol"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="0" loc="(620,1140)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="5"/>
+      <a name="appear" val="right"/>
+      <a name="bit4" val="none"/>
+    </comp>
+    <comp lib="3" loc="(310,300)" name="Adder">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(760,930)" name="Splitter">
       <a name="facing" val="west"/>
       <a name="fanout" val="16"/>
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(230,340)" name="Constant">
+      <a name="width" val="5"/>
     </comp>
     <comp lib="0" loc="(580,700)" name="Splitter">
       <a name="facing" val="west"/>
@@ -6679,45 +6606,8 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(540,1720)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="6" loc="(659,680)" name="Text">
-      <a name="text" val="shr"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="3" loc="(700,1130)" name="Shifter">
-      <a name="width" val="16"/>
-      <a name="shift" val="rl"/>
-    </comp>
-    <comp lib="0" loc="(660,1140)" name="Splitter">
+    <comp lib="0" loc="(580,1500)" name="Splitter">
       <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-    </comp>
-    <comp lib="6" loc="(681,1292)" name="Text">
-      <a name="text" val="ror"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="0" loc="(150,120)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="In"/>
-    </comp>
-    <comp lib="0" loc="(1070,670)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1070,440)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(720,710)" name="Splitter">
       <a name="fanout" val="17"/>
       <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
@@ -6727,24 +6617,6 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="3" loc="(310,300)" name="Adder">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="6" loc="(659,1689)" name="Text">
-      <a name="text" val="rcr"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="0" loc="(540,490)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(760,1510)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
     <comp lib="0" loc="(1110,390)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -6752,37 +6624,165 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="Out"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(150,230)" name="Pin">
+    <comp lib="0" loc="(1070,670)" name="Tunnel">
       <a name="width" val="3"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="shift_type"/>
+      <a name="label" val="type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(760,930)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
+    <comp lib="3" loc="(700,1130)" name="Shifter">
+      <a name="width" val="16"/>
+      <a name="shift" val="rl"/>
     </comp>
     <comp lib="2" loc="(1080,390)" name="Multiplexer">
       <a name="select" val="3"/>
       <a name="width" val="16"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1110,620)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="cout"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(560,1580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(660,1330)" name="Splitter">
+    <comp lib="0" loc="(220,290)" name="Bit Extender">
+      <a name="in_width" val="3"/>
+      <a name="out_width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(760,500)" name="Splitter">
       <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
     </comp>
     <comp lib="2" loc="(1080,620)" name="Multiplexer">
       <a name="select" val="3"/>
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(580,1710)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="3" loc="(680,1720)" name="Shifter">
+      <a name="width" val="17"/>
+      <a name="shift" val="rr"/>
+    </comp>
+    <comp lib="6" loc="(681,1292)" name="Text">
+      <a name="text" val="ror"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="0" loc="(760,1350)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="0"/>
+    </comp>
+    <comp lib="0" loc="(720,920)" name="Splitter">
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="6" loc="(658,465)" name="Text">
+      <a name="text" val="shl"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="6" loc="(659,680)" name="Text">
+      <a name="text" val="shr"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="0" loc="(760,1510)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(310,440)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(660,1140)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+    </comp>
+    <comp lib="6" loc="(659,1689)" name="Text">
+      <a name="text" val="rcr"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="0" loc="(540,1720)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="6" loc="(660,1477)" name="Text">
+      <a name="text" val="rcl"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="6" loc="(659,890)" name="Text">
+      <a name="text" val="shra"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="0" loc="(160,230)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="3" loc="(680,920)" name="Shifter">
+      <a name="width" val="17"/>
+      <a name="shift" val="ar"/>
+    </comp>
+    <comp lib="0" loc="(620,1330)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="5"/>
+      <a name="appear" val="right"/>
+      <a name="bit4" val="none"/>
+    </comp>
+    <comp lib="3" loc="(680,1510)" name="Shifter">
+      <a name="width" val="17"/>
+      <a name="shift" val="rl"/>
+    </comp>
+    <comp lib="0" loc="(720,1720)" name="Splitter">
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(160,180)" name="Tunnel">
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(540,1500)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(150,230)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="shift_type"/>
+    </comp>
+    <comp lib="0" loc="(150,290)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="distance"/>
     </comp>
   </circuit>
   <circuit name="adder16">
@@ -6869,16 +6869,56 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(700,550)" to="(700,610)"/>
     <wire from="(430,400)" to="(430,460)"/>
     <wire from="(720,410)" to="(730,410)"/>
-    <comp lib="0" loc="(680,350)" name="Splitter">
+    <comp lib="0" loc="(800,240)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="S"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(750,340)" name="Splitter">
+      <a name="facing" val="west"/>
       <a name="fanout" val="16"/>
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(700,610)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="output" val="true"/>
+      <a name="label" val="Cout"/>
+      <a name="labelloc" val="south"/>
+    </comp>
+    <comp lib="0" loc="(690,120)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="Cin"/>
+    </comp>
+    <comp lib="1" loc="(780,540)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(230,220)" name="Pin">
       <a name="width" val="16"/>
       <a name="tristate" val="false"/>
       <a name="pull" val="down"/>
       <a name="label" val="A"/>
+    </comp>
+    <comp lib="1" loc="(510,310)" name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(760,220)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="10signed"/>
+    </comp>
+    <comp lib="0" loc="(230,260)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="B"/>
     </comp>
     <comp lib="1" loc="(550,240)" name="XOR Gate">
       <a name="width" val="16"/>
@@ -6891,72 +6931,32 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="V"/>
       <a name="labelloc" val="south"/>
     </comp>
-    <comp lib="0" loc="(700,610)" name="Pin">
-      <a name="facing" val="north"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Cout"/>
-      <a name="labelloc" val="south"/>
+    <comp lib="0" loc="(270,210)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="10signed"/>
     </comp>
-    <comp lib="1" loc="(590,350)" name="OR Gate">
-      <a name="width" val="16"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(800,240)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="S"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="0" loc="(680,350)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
     </comp>
     <comp lib="1" loc="(510,390)" name="AND Gate">
       <a name="width" val="16"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(760,220)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="0" loc="(270,270)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="1" loc="(510,310)" name="AND Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(690,120)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="Cin"/>
-    </comp>
     <comp lib="1" loc="(510,350)" name="AND Gate">
       <a name="width" val="16"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(270,210)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="0" loc="(750,340)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="1" loc="(780,540)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(230,260)" name="Pin">
+    <comp lib="1" loc="(590,350)" name="OR Gate">
       <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="B"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(270,270)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
     </comp>
   </circuit>
   <circuit name="branch_logic">
@@ -7074,72 +7074,48 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(820,540)" to="(960,540)"/>
     <wire from="(420,330)" to="(420,390)"/>
     <wire from="(1110,440)" to="(1110,610)"/>
-    <comp lib="6" loc="(1016,443)" name="Text">
-      <a name="text" val="HI"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="6" loc="(644,392)" name="Text">
-      <a name="text" val="VS"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="6" loc="(643,302)" name="Text">
-      <a name="text" val="EQ"/>
+    <comp lib="6" loc="(643,335)" name="Text">
+      <a name="text" val="HS/CS"/>
       <a name="font" val="SansSerif plain 18"/>
     </comp>
     <comp lib="1" loc="(600,400)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="6" loc="(642,362)" name="Text">
-      <a name="text" val="MI"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="1" loc="(620,600)" name="NOT Gate"/>
-    <comp lib="1" loc="(990,460)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(990,610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="6" loc="(643,335)" name="Text">
-      <a name="text" val="HS/CS"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="6" loc="(330,563)" name="Text">
-      <a name="text" val="N"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="1" loc="(1280,290)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(740,450)" name="Decoder">
-      <a name="selloc" val="tr"/>
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="6" loc="(1016,600)" name="Text">
-      <a name="text" val="GT"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="0" loc="(160,320)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
+    <comp lib="0" loc="(200,320)" name="Splitter">
+      <a name="facing" val="west"/>
       <a name="appear" val="center"/>
+    </comp>
+    <comp lib="6" loc="(1014,518)" name="Text">
+      <a name="text" val="GE"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="6" loc="(644,392)" name="Text">
+      <a name="text" val="VS"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="1" loc="(1210,410)" name="OR Gate">
+      <a name="inputs" val="8"/>
+    </comp>
+    <comp lib="6" loc="(643,302)" name="Text">
+      <a name="text" val="EQ"/>
+      <a name="font" val="SansSerif plain 18"/>
     </comp>
     <comp lib="6" loc="(756,541)" name="Text">
       <a name="text" val="N=V"/>
       <a name="font" val="SansSerif plain 18"/>
     </comp>
-    <comp lib="2" loc="(370,340)" name="Decoder">
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
+    <comp lib="6" loc="(1016,443)" name="Text">
+      <a name="text" val="HI"/>
+      <a name="font" val="SansSerif plain 18"/>
     </comp>
-    <comp lib="1" loc="(990,530)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="6" loc="(1025,678)" name="Text">
+      <a name="text" val="&lt;always&gt;"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="6" loc="(330,623)" name="Text">
+      <a name="text" val="V"/>
+      <a name="font" val="SansSerif plain 18"/>
     </comp>
     <comp lib="1" loc="(250,340)" name="NOT Gate">
       <a name="size" val="20"/>
@@ -7148,49 +7124,41 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(200,320)" name="Splitter">
-      <a name="facing" val="west"/>
+    <comp lib="0" loc="(160,320)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="1" loc="(700,520)" name="XNOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="2" loc="(370,340)" name="Decoder">
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
     </comp>
-    <comp lib="6" loc="(744,594)" name="Text">
-      <a name="text" val="Z'"/>
+    <comp lib="6" loc="(330,594)" name="Text">
+      <a name="text" val="Z"/>
       <a name="font" val="SansSerif plain 18"/>
     </comp>
-    <comp lib="6" loc="(330,623)" name="Text">
-      <a name="text" val="V"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="6" loc="(1014,518)" name="Text">
-      <a name="text" val="GE"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="1" loc="(1210,410)" name="OR Gate">
-      <a name="inputs" val="8"/>
-    </comp>
-    <comp lib="1" loc="(570,370)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(120,320)" name="Pin">
+    <comp lib="0" loc="(120,610)" name="Pin">
       <a name="width" val="4"/>
       <a name="tristate" val="false"/>
-      <a name="label" val="cccc"/>
+      <a name="label" val="CVZN"/>
+    </comp>
+    <comp lib="1" loc="(1280,290)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="6" loc="(328,653)" name="Text">
       <a name="text" val="C"/>
       <a name="font" val="SansSerif plain 18"/>
     </comp>
-    <comp lib="1" loc="(510,310)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="2" loc="(740,450)" name="Decoder">
+      <a name="selloc" val="tr"/>
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
     </comp>
-    <comp lib="6" loc="(330,594)" name="Text">
-      <a name="text" val="Z"/>
-      <a name="font" val="SansSerif plain 18"/>
+    <comp lib="0" loc="(120,320)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="cccc"/>
     </comp>
     <comp lib="0" loc="(1300,290)" name="Pin">
       <a name="facing" val="west"/>
@@ -7199,19 +7167,51 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="go"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(120,610)" name="Pin">
-      <a name="width" val="4"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="CVZN"/>
+    <comp lib="6" loc="(744,594)" name="Text">
+      <a name="text" val="Z'"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="6" loc="(642,362)" name="Text">
+      <a name="text" val="MI"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="1" loc="(990,610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="6" loc="(330,563)" name="Text">
+      <a name="text" val="N"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="1" loc="(700,520)" name="XNOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(990,530)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(510,310)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(160,610)" name="Splitter">
       <a name="fanout" val="4"/>
       <a name="incoming" val="4"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="6" loc="(1025,678)" name="Text">
-      <a name="text" val="&lt;always&gt;"/>
+    <comp lib="1" loc="(990,460)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="1" loc="(620,600)" name="NOT Gate"/>
+    <comp lib="6" loc="(1016,600)" name="Text">
+      <a name="text" val="GT"/>
       <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="1" loc="(570,370)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
   </circuit>
   <circuit name="zero16">
@@ -7287,6 +7287,12 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
+    <comp lib="0" loc="(720,330)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="zero"/>
+      <a name="labelloc" val="east"/>
+    </comp>
     <comp lib="1" loc="(630,280)" name="NOR Gate">
       <a name="inputs" val="8"/>
     </comp>
@@ -7295,19 +7301,13 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="tristate" val="false"/>
       <a name="label" val="in"/>
     </comp>
+    <comp lib="1" loc="(630,380)" name="NOR Gate">
+      <a name="inputs" val="8"/>
+    </comp>
     <comp lib="0" loc="(340,320)" name="Splitter">
       <a name="fanout" val="16"/>
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(720,330)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="zero"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(630,380)" name="NOR Gate">
-      <a name="inputs" val="8"/>
     </comp>
   </circuit>
   <circuit name="2s_compliment">
@@ -7325,11 +7325,6 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(480,500)" to="(490,500)"/>
     <wire from="(530,500)" to="(540,500)"/>
     <wire from="(580,500)" to="(590,500)"/>
-    <comp lib="0" loc="(480,500)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="In"/>
-    </comp>
     <comp lib="0" loc="(590,500)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -7339,6 +7334,11 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     </comp>
     <comp lib="0" loc="(580,500)" name="Bit Extender">
       <a name="type" val="sign"/>
+    </comp>
+    <comp lib="0" loc="(480,500)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="In"/>
     </comp>
     <comp lib="0" loc="(530,500)" name="Bit Extender">
       <a name="in_width" val="16"/>
@@ -7360,11 +7360,11 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(480,500)" to="(490,500)"/>
     <wire from="(530,500)" to="(540,500)"/>
     <wire from="(580,500)" to="(590,500)"/>
-    <comp lib="0" loc="(530,500)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="8"/>
+    <comp lib="0" loc="(480,500)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="In"/>
     </comp>
-    <comp lib="0" loc="(580,500)" name="Bit Extender"/>
     <comp lib="0" loc="(590,500)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -7372,11 +7372,11 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="Out"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(480,500)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="In"/>
+    <comp lib="0" loc="(530,500)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="8"/>
     </comp>
+    <comp lib="0" loc="(580,500)" name="Bit Extender"/>
   </circuit>
   <circuit name="bytes_swap">
     <a name="circuit" val="bytes_swap"/>
@@ -7405,30 +7405,12 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="incoming" val="8"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(660,510)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="Out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(650,510)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(610,470)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
     <comp lib="0" loc="(530,510)" name="Splitter">
       <a name="fanout" val="16"/>
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(570,550)" name="Splitter">
+    <comp lib="0" loc="(570,470)" name="Splitter">
       <a name="facing" val="west"/>
       <a name="fanout" val="8"/>
       <a name="incoming" val="8"/>
@@ -7439,7 +7421,25 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="tristate" val="false"/>
       <a name="label" val="In"/>
     </comp>
-    <comp lib="0" loc="(570,470)" name="Splitter">
+    <comp lib="0" loc="(610,470)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(650,510)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(660,510)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="Out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(570,550)" name="Splitter">
       <a name="facing" val="west"/>
       <a name="fanout" val="8"/>
       <a name="incoming" val="8"/>

--- a/logisim/cdm16/cdm16.circ
+++ b/logisim/cdm16/cdm16.circ
@@ -150,7 +150,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <circ-port height="10" pin="2210,550" width="10" x="205" y="115"/>
       <circ-port height="10" pin="1970,500" width="10" x="205" y="145"/>
       <circ-port height="10" pin="2210,610" width="10" x="205" y="125"/>
-      <circ-port height="10" pin="860,1710" width="10" x="85" y="115"/>
       <circ-port height="10" pin="210,550" width="10" x="95" y="65"/>
       <circ-port height="10" pin="130,580" width="10" x="105" y="65"/>
       <circ-port height="10" pin="210,610" width="10" x="115" y="65"/>
@@ -167,6 +166,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <circ-port height="10" pin="2240,720" width="10" x="205" y="165"/>
       <circ-port height="8" pin="2240,770" width="8" x="206" y="176"/>
       <circ-port height="8" pin="120,1380" width="8" x="106" y="186"/>
+      <circ-port height="10" pin="720,1700" width="10" x="135" y="195"/>
       <circ-anchor facing="north" height="6" width="6" x="147" y="137"/>
     </appear>
     <wire from="(1400,440)" to="(1400,460)"/>
@@ -203,8 +203,10 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(660,660)" to="(660,720)"/>
     <wire from="(1780,1250)" to="(1800,1250)"/>
     <wire from="(540,790)" to="(540,1030)"/>
+    <wire from="(930,1690)" to="(940,1690)"/>
     <wire from="(1620,440)" to="(1650,440)"/>
     <wire from="(670,790)" to="(680,790)"/>
+    <wire from="(650,1730)" to="(660,1730)"/>
     <wire from="(2600,1190)" to="(2600,1280)"/>
     <wire from="(1830,650)" to="(1860,650)"/>
     <wire from="(600,1050)" to="(600,1060)"/>
@@ -236,6 +238,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(180,1070)" to="(190,1070)"/>
     <wire from="(220,1110)" to="(230,1110)"/>
     <wire from="(1710,1310)" to="(1730,1310)"/>
+    <wire from="(930,1820)" to="(940,1820)"/>
     <wire from="(2470,930)" to="(2470,1150)"/>
     <wire from="(1260,1390)" to="(1260,1430)"/>
     <wire from="(630,1520)" to="(640,1520)"/>
@@ -321,6 +324,8 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1590,820)" to="(1600,820)"/>
     <wire from="(2540,1070)" to="(2540,1220)"/>
     <wire from="(130,1600)" to="(140,1600)"/>
+    <wire from="(890,1720)" to="(900,1720)"/>
+    <wire from="(960,1470)" to="(970,1470)"/>
     <wire from="(2300,1180)" to="(2340,1180)"/>
     <wire from="(530,720)" to="(540,720)"/>
     <wire from="(610,800)" to="(620,800)"/>
@@ -363,7 +368,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1170,1560)" to="(1170,1660)"/>
     <wire from="(790,790)" to="(800,790)"/>
     <wire from="(660,790)" to="(660,1030)"/>
-    <wire from="(800,1760)" to="(810,1760)"/>
     <wire from="(1610,1590)" to="(1640,1590)"/>
     <wire from="(630,1590)" to="(640,1590)"/>
     <wire from="(620,1580)" to="(630,1580)"/>
@@ -409,6 +413,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(760,1210)" to="(770,1210)"/>
     <wire from="(1610,1720)" to="(1640,1720)"/>
     <wire from="(670,800)" to="(680,800)"/>
+    <wire from="(660,1750)" to="(670,1750)"/>
     <wire from="(590,720)" to="(600,720)"/>
     <wire from="(690,830)" to="(690,840)"/>
     <wire from="(570,1030)" to="(570,1040)"/>
@@ -468,7 +473,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1370,1110)" to="(1390,1110)"/>
     <wire from="(1380,480)" to="(1400,480)"/>
     <wire from="(720,670)" to="(720,720)"/>
-    <wire from="(800,1830)" to="(810,1830)"/>
+    <wire from="(980,1690)" to="(990,1690)"/>
     <wire from="(1290,1560)" to="(1290,1600)"/>
     <wire from="(650,720)" to="(660,720)"/>
     <wire from="(730,800)" to="(740,800)"/>
@@ -511,11 +516,13 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1680,910)" to="(1700,910)"/>
     <wire from="(210,730)" to="(220,730)"/>
     <wire from="(1310,1500)" to="(1330,1500)"/>
+    <wire from="(970,1810)" to="(980,1810)"/>
     <wire from="(760,1280)" to="(770,1280)"/>
     <wire from="(290,960)" to="(740,960)"/>
     <wire from="(2070,1060)" to="(2070,1160)"/>
     <wire from="(780,790)" to="(780,1030)"/>
     <wire from="(2350,1560)" to="(2390,1560)"/>
+    <wire from="(660,1820)" to="(670,1820)"/>
     <wire from="(590,790)" to="(600,790)"/>
     <wire from="(2460,910)" to="(2690,910)"/>
     <wire from="(1360,1570)" to="(1360,1590)"/>
@@ -590,7 +597,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(670,760)" to="(730,760)"/>
     <wire from="(1790,1170)" to="(1790,1190)"/>
     <wire from="(2620,1230)" to="(2690,1230)"/>
-    <wire from="(800,1780)" to="(800,1810)"/>
     <wire from="(2510,1570)" to="(2510,1620)"/>
     <wire from="(2230,770)" to="(2240,770)"/>
     <wire from="(1240,1450)" to="(1240,1520)"/>
@@ -615,6 +621,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(2580,1150)" to="(2690,1150)"/>
     <wire from="(1680,850)" to="(1700,850)"/>
     <wire from="(210,670)" to="(220,670)"/>
+    <wire from="(930,1710)" to="(940,1710)"/>
     <wire from="(1390,1200)" to="(1410,1200)"/>
     <wire from="(1790,630)" to="(1820,630)"/>
     <wire from="(1580,420)" to="(1610,420)"/>
@@ -642,6 +649,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1690,880)" to="(1690,890)"/>
     <wire from="(820,970)" to="(820,1000)"/>
     <wire from="(460,1250)" to="(460,1270)"/>
+    <wire from="(660,1770)" to="(660,1800)"/>
     <wire from="(1230,1570)" to="(1230,1640)"/>
     <wire from="(610,760)" to="(610,790)"/>
     <wire from="(2410,1350)" to="(2670,1350)"/>
@@ -687,7 +695,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(2140,620)" to="(2150,620)"/>
     <wire from="(2200,680)" to="(2210,680)"/>
     <wire from="(1210,1170)" to="(1210,1180)"/>
-    <wire from="(800,1720)" to="(800,1740)"/>
     <wire from="(1190,510)" to="(1190,520)"/>
     <wire from="(1250,890)" to="(1250,900)"/>
     <wire from="(840,540)" to="(840,690)"/>
@@ -725,6 +732,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(2250,1500)" to="(2260,1500)"/>
     <wire from="(2280,890)" to="(2290,890)"/>
     <wire from="(2200,810)" to="(2210,810)"/>
+    <wire from="(660,1710)" to="(660,1730)"/>
     <wire from="(1390,1160)" to="(1390,1170)"/>
     <wire from="(1360,1570)" to="(1370,1570)"/>
     <wire from="(1210,780)" to="(1220,780)"/>
@@ -777,8 +785,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(2410,1190)" to="(2510,1190)"/>
     <wire from="(770,790)" to="(780,790)"/>
     <wire from="(800,1460)" to="(810,1460)"/>
-    <wire from="(800,1780)" to="(810,1780)"/>
-    <wire from="(750,1730)" to="(760,1730)"/>
     <wire from="(630,1610)" to="(640,1610)"/>
     <wire from="(650,1630)" to="(660,1630)"/>
     <wire from="(2410,1320)" to="(2640,1320)"/>
@@ -821,6 +827,8 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1990,1490)" to="(2010,1490)"/>
     <wire from="(1320,500)" to="(1340,500)"/>
     <wire from="(760,1230)" to="(770,1230)"/>
+    <wire from="(660,1770)" to="(670,1770)"/>
+    <wire from="(610,1720)" to="(620,1720)"/>
     <wire from="(1120,1140)" to="(1330,1140)"/>
     <wire from="(760,1320)" to="(810,1320)"/>
     <wire from="(440,990)" to="(500,990)"/>
@@ -836,7 +844,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(2410,1290)" to="(2610,1290)"/>
     <wire from="(2410,1160)" to="(2480,1160)"/>
     <wire from="(600,500)" to="(600,650)"/>
-    <wire from="(790,1700)" to="(810,1700)"/>
     <wire from="(890,1480)" to="(910,1480)"/>
     <wire from="(1350,1630)" to="(1360,1630)"/>
     <wire from="(1180,820)" to="(1190,820)"/>
@@ -857,7 +864,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1390,1020)" to="(1410,1020)"/>
     <wire from="(830,790)" to="(840,790)"/>
     <wire from="(1470,1100)" to="(1490,1100)"/>
-    <wire from="(800,1720)" to="(810,1720)"/>
     <wire from="(570,1490)" to="(580,1490)"/>
     <wire from="(580,870)" to="(580,880)"/>
     <wire from="(590,1200)" to="(590,1210)"/>
@@ -884,6 +890,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1350,1440)" to="(1360,1440)"/>
     <wire from="(1250,1400)" to="(1330,1400)"/>
     <wire from="(1390,1160)" to="(1400,1160)"/>
+    <wire from="(650,1690)" to="(670,1690)"/>
     <wire from="(1160,1640)" to="(1230,1640)"/>
     <wire from="(1700,1670)" to="(1700,1720)"/>
     <wire from="(2320,1650)" to="(2320,1660)"/>
@@ -895,6 +902,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1010,1540)" to="(1160,1540)"/>
     <wire from="(1610,1680)" to="(1640,1680)"/>
     <wire from="(670,1400)" to="(680,1400)"/>
+    <wire from="(660,1710)" to="(670,1710)"/>
     <wire from="(570,1620)" to="(580,1620)"/>
     <wire from="(1910,1460)" to="(1950,1460)"/>
     <wire from="(1900,1450)" to="(1940,1450)"/>
@@ -951,7 +959,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(2640,1270)" to="(2640,1320)"/>
     <wire from="(1390,980)" to="(1390,990)"/>
     <wire from="(1440,510)" to="(1450,510)"/>
-    <wire from="(840,1820)" to="(860,1820)"/>
     <wire from="(1160,1510)" to="(1170,1510)"/>
     <wire from="(2240,1510)" to="(2240,1520)"/>
     <wire from="(490,830)" to="(510,830)"/>
@@ -996,6 +1003,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1320,520)" to="(1330,520)"/>
     <wire from="(370,1470)" to="(400,1470)"/>
     <wire from="(570,1040)" to="(590,1040)"/>
+    <wire from="(700,1810)" to="(720,1810)"/>
     <wire from="(1160,1390)" to="(1230,1390)"/>
     <wire from="(1900,1420)" to="(1910,1420)"/>
     <wire from="(440,910)" to="(460,910)"/>
@@ -1081,7 +1089,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1730,1710)" to="(1730,1720)"/>
     <wire from="(1790,490)" to="(1790,500)"/>
     <wire from="(2230,1370)" to="(2240,1370)"/>
-    <wire from="(800,1740)" to="(800,1760)"/>
     <wire from="(480,630)" to="(900,630)"/>
     <wire from="(1260,1560)" to="(1260,1610)"/>
     <wire from="(1180,1020)" to="(1260,1020)"/>
@@ -1107,6 +1114,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1900,730)" to="(1900,760)"/>
     <wire from="(1870,1660)" to="(1870,1690)"/>
     <wire from="(1180,1350)" to="(1180,1500)"/>
+    <wire from="(930,1680)" to="(930,1690)"/>
     <wire from="(1750,1220)" to="(1750,1250)"/>
     <wire from="(130,1520)" to="(130,1530)"/>
     <wire from="(1740,1210)" to="(1740,1230)"/>
@@ -1120,6 +1128,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(370,800)" to="(370,830)"/>
     <wire from="(660,510)" to="(660,660)"/>
     <wire from="(360,880)" to="(400,880)"/>
+    <wire from="(660,1730)" to="(660,1750)"/>
     <wire from="(1520,1110)" to="(1530,1110)"/>
     <wire from="(1390,980)" to="(1400,980)"/>
     <wire from="(1360,1590)" to="(1370,1590)"/>
@@ -1141,6 +1150,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1300,1510)" to="(1330,1510)"/>
     <wire from="(1780,1040)" to="(1800,1040)"/>
     <wire from="(1740,670)" to="(1770,670)"/>
+    <wire from="(930,1800)" to="(940,1800)"/>
     <wire from="(620,1490)" to="(630,1490)"/>
     <wire from="(630,1500)" to="(640,1500)"/>
     <wire from="(1200,460)" to="(1220,460)"/>
@@ -1150,6 +1160,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1790,1260)" to="(1790,1350)"/>
     <wire from="(2090,730)" to="(2090,760)"/>
     <wire from="(570,810)" to="(570,820)"/>
+    <wire from="(950,1830)" to="(950,1840)"/>
     <wire from="(870,1430)" to="(870,1440)"/>
     <wire from="(2500,1650)" to="(2500,1760)"/>
     <wire from="(130,1650)" to="(130,1660)"/>
@@ -1189,7 +1200,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1320,1030)" to="(1340,1030)"/>
     <wire from="(2390,1670)" to="(2390,1700)"/>
     <wire from="(800,1480)" to="(810,1480)"/>
-    <wire from="(750,1750)" to="(760,1750)"/>
     <wire from="(1610,1630)" to="(1640,1630)"/>
     <wire from="(1550,940)" to="(1570,940)"/>
     <wire from="(620,1620)" to="(630,1620)"/>
@@ -1224,9 +1234,11 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(120,1570)" to="(130,1570)"/>
     <wire from="(500,870)" to="(500,920)"/>
     <wire from="(930,460)" to="(940,460)"/>
+    <wire from="(890,1700)" to="(900,1700)"/>
     <wire from="(800,1290)" to="(810,1290)"/>
     <wire from="(1250,1620)" to="(1250,1660)"/>
     <wire from="(1940,1450)" to="(1970,1450)"/>
+    <wire from="(610,1740)" to="(620,1740)"/>
     <wire from="(630,810)" to="(630,820)"/>
     <wire from="(1790,690)" to="(1790,720)"/>
     <wire from="(1160,1430)" to="(1200,1430)"/>
@@ -1244,7 +1256,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(2190,770)" to="(2190,830)"/>
     <wire from="(1530,750)" to="(1530,760)"/>
     <wire from="(840,1450)" to="(860,1450)"/>
-    <wire from="(840,1770)" to="(860,1770)"/>
     <wire from="(1410,430)" to="(1420,430)"/>
     <wire from="(1070,730)" to="(1080,730)"/>
     <wire from="(750,1040)" to="(770,1040)"/>
@@ -1297,6 +1308,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1330,480)" to="(1340,480)"/>
     <wire from="(500,920)" to="(520,920)"/>
     <wire from="(730,830)" to="(750,830)"/>
+    <wire from="(700,1760)" to="(720,1760)"/>
     <wire from="(2460,1570)" to="(2510,1570)"/>
     <wire from="(1220,1400)" to="(1220,1520)"/>
     <wire from="(1790,1260)" to="(1800,1260)"/>
@@ -1316,6 +1328,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(2460,910)" to="(2460,1140)"/>
     <wire from="(1950,790)" to="(1950,820)"/>
     <wire from="(1130,1570)" to="(1130,1590)"/>
+    <wire from="(960,1720)" to="(960,1730)"/>
     <wire from="(1230,800)" to="(1270,800)"/>
     <wire from="(390,830)" to="(390,840)"/>
     <wire from="(2130,760)" to="(2150,760)"/>
@@ -1326,7 +1339,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1070,1510)" to="(1070,1520)"/>
     <wire from="(1390,1190)" to="(1390,1200)"/>
     <wire from="(810,1040)" to="(830,1040)"/>
-    <wire from="(840,1710)" to="(860,1710)"/>
     <wire from="(290,900)" to="(380,900)"/>
     <wire from="(1180,840)" to="(1260,840)"/>
     <wire from="(1350,1590)" to="(1360,1590)"/>
@@ -1361,10 +1373,10 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(350,1560)" to="(350,1590)"/>
     <wire from="(200,1500)" to="(240,1500)"/>
     <wire from="(790,830)" to="(810,830)"/>
-    <wire from="(780,1780)" to="(800,1780)"/>
     <wire from="(1510,920)" to="(1520,920)"/>
     <wire from="(1060,670)" to="(1060,720)"/>
     <wire from="(990,1560)" to="(990,1600)"/>
+    <wire from="(700,1700)" to="(720,1700)"/>
     <wire from="(2030,1440)" to="(2040,1440)"/>
     <wire from="(2410,1270)" to="(2590,1270)"/>
     <wire from="(2410,1140)" to="(2460,1140)"/>
@@ -1381,7 +1393,6 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1390,1110)" to="(1410,1110)"/>
     <wire from="(700,950)" to="(700,1000)"/>
     <wire from="(1580,1610)" to="(1610,1610)"/>
-    <wire from="(800,1810)" to="(810,1810)"/>
     <wire from="(570,1580)" to="(580,1580)"/>
     <wire from="(750,810)" to="(750,820)"/>
     <wire from="(1360,1420)" to="(1360,1440)"/>
@@ -1410,6 +1421,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1350,570)" to="(1360,570)"/>
     <wire from="(1210,430)" to="(1220,430)"/>
     <wire from="(1060,410)" to="(1200,410)"/>
+    <wire from="(640,1770)" to="(660,1770)"/>
     <wire from="(1130,1630)" to="(1140,1630)"/>
     <wire from="(2170,950)" to="(2170,960)"/>
     <wire from="(290,910)" to="(440,910)"/>
@@ -1426,6 +1438,7 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(1670,870)" to="(1700,870)"/>
     <wire from="(910,450)" to="(920,450)"/>
     <wire from="(650,1150)" to="(660,1150)"/>
+    <wire from="(660,1800)" to="(670,1800)"/>
     <wire from="(1690,660)" to="(1690,760)"/>
     <wire from="(1100,950)" to="(1120,950)"/>
     <wire from="(610,790)" to="(620,790)"/>
@@ -1466,47 +1479,83 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
     <wire from="(440,1710)" to="(450,1710)"/>
     <wire from="(1300,1590)" to="(1330,1590)"/>
     <wire from="(1180,1560)" to="(1180,1660)"/>
-    <wire from="(790,1740)" to="(800,1740)"/>
     <wire from="(700,1330)" to="(710,1330)"/>
     <wire from="(610,1240)" to="(620,1240)"/>
     <wire from="(620,1250)" to="(630,1250)"/>
-    <comp lib="1" loc="(1940,820)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(1370,1400)" name="Tunnel">
+    <comp lib="0" loc="(2050,1730)" name="Tunnel">
+      <a name="facing" val="north"/>
       <a name="width" val="3"/>
-      <a name="label" val="alu_op_d0"/>
+      <a name="label" val="phase"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="4" loc="(180,1500)" name="S-R Flip-Flop">
+    <comp lib="0" loc="(340,1720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="CUT"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1810,810)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="0"/>
+    </comp>
+    <comp lib="4" loc="(170,1770)" name="Counter">
+      <a name="width" val="3"/>
+      <a name="max" val="0x7"/>
       <a name="trigger" val="falling"/>
     </comp>
-    <comp lib="0" loc="(790,1700)" name="Tunnel">
+    <comp lib="0" loc="(120,1590)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
+      <a name="label" val="clk_no_inhibit"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1080,730)" name="Tunnel">
-      <a name="label" val="imm_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="1" loc="(1060,610)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
     </comp>
-    <comp lib="0" loc="(1710,1230)" name="Tunnel">
+    <comp lib="0" loc="(210,730)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R6"/>
+    </comp>
+    <comp lib="0" loc="(1710,1290)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="alu3_ind"/>
+      <a name="label" val="br_rel_n"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(620,1530)" name="Bit Extender">
-      <a name="in_width" val="6"/>
+    <comp lib="0" loc="(940,710)" name="Tunnel">
+      <a name="label" val="r_asrt1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1350,1500)" name="Tunnel">
+    <comp lib="0" loc="(1170,1030)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="X"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(990,1690)" name="Tunnel">
+      <a name="label" val="virtual_instruction"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(823,1119)" name="Text">
+      <a name="text" val="2. Multiple exceptions on the same phase"/>
+    </comp>
+    <comp lib="1" loc="(1640,730)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="2" loc="(2220,1490)" name="Multiplexer">
+      <a name="facing" val="west"/>
       <a name="width" val="3"/>
-      <a name="label" val="rd_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1710,1330)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_rel_nop"/>
+    <comp lib="4" loc="(1000,1540)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(2690,1370)" name="Tunnel">
+      <a name="label" val="CUT"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1160,1540)" name="Splitter">
@@ -1515,247 +1564,69 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="incoming" val="16"/>
       <a name="appear" val="right"/>
     </comp>
-    <comp lib="1" loc="(1410,500)" name="AND Gate">
-      <a name="facing" val="west"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="0" loc="(710,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="r5"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1680,1590)" name="Bit Extender">
-      <a name="in_width" val="9"/>
+    <comp lib="0" loc="(1880,970)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(270,980)" name="Decoder">
-      <a name="select" val="3"/>
+    <comp lib="2" loc="(670,1600)" name="Multiplexer">
+      <a name="width" val="16"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="1" loc="(2340,1120)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(1400,420)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(900,1600)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
+    <comp lib="0" loc="(1360,1630)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d1"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(130,460)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="PC"/>
-    </comp>
-    <comp lib="2" loc="(1150,1010)" name="Demultiplexer">
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(360,1560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="2"/>
-      <a name="label" val="status"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="4" loc="(710,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(1560,910)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="1" loc="(1650,440)" name="AND Gate">
-      <a name="facing" val="west"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2300,1160)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="0"/>
-    </comp>
-    <comp lib="6" loc="(551,1117)" name="Text">
-      <a name="text" val="3"/>
-    </comp>
-    <comp lib="0" loc="(810,1320)" name="Tunnel">
-      <a name="label" val="exc_latch"/>
+    <comp lib="0" loc="(1700,850)" name="Tunnel">
+      <a name="label" val="halt"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1620,800)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="imm9"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,1770)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1830,540)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1640,730)" name="Controlled Buffer">
+    <comp lib="1" loc="(600,1050)" name="Controlled Buffer">
       <a name="facing" val="south"/>
       <a name="width" val="16"/>
     </comp>
-    <comp lib="0" loc="(1660,540)" name="Tunnel">
+    <comp lib="0" loc="(1140,1400)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="width" val="3"/>
-      <a name="label" val="shift_count_d"/>
+      <a name="label" val="alu_op_d1"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1080,670)" name="Tunnel">
+    <comp lib="0" loc="(1710,1330)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_rel_nop"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2300,1650)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="imm6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(370,760)" name="Pull Resistor">
+      <a name="facing" val="east"/>
+    </comp>
+    <comp lib="3" loc="(1960,1610)" name="Shifter">
       <a name="width" val="16"/>
-      <a name="label" val="imm"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,930)" name="Tunnel">
-      <a name="label" val="imm_extend_negative"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(310,1500)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(2300,1180)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="startup"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(2050,1766)" name="Text">
-      <a name="text" val="1, 3, 5, 7"/>
-    </comp>
-    <comp lib="6" loc="(754,1100)" name="Text">
-      <a name="text" val="Double fault: 1. Unrecoverable instruction"/>
-    </comp>
-    <comp lib="0" loc="(2060,630)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(750,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2690,1230)" name="Tunnel">
-      <a name="label" val="sign_extend"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1620,820)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="4" loc="(180,1660)" name="S-R Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(2690,990)" name="Tunnel">
-      <a name="label" val="pc_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1430,1150)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(1320,500)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="exc_triggered"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2690,1030)" name="Tunnel">
-      <a name="label" val="pc_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(800,1220)" name="AND Gate">
+    <comp lib="1" loc="(520,1210)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(1170,1030)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="X"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1080,620)" name="Tunnel">
-      <a name="label" val="imm_asrt1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1060,610)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1060,450)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-      <a name="label" val="fp"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2140,680)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-    </comp>
-    <comp lib="0" loc="(2270,1450)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rd_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1410,1200)" name="Tunnel">
-      <a name="label" val="br_rel_p"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1740,1120)" name="Tunnel">
+    <comp lib="0" loc="(1740,1020)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="mem3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1270)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_rel_p"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1130,510)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="sp_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2300,1220)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1880,930)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(770,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="6" loc="(823,1119)" name="Text">
-      <a name="text" val="2. Multiple exceptions on the same phase"/>
-    </comp>
-    <comp lib="0" loc="(590,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="r3"/>
+      <a name="label" val="1op"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1880,890)" name="Tunnel">
@@ -1764,1163 +1635,27 @@ This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
       <a name="label" val="op_type_d1"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(860,1770)" name="Tunnel">
-      <a name="label" val="latch_int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(120,1440)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="hold"/>
-    </comp>
-    <comp lib="0" loc="(760,1210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="double_fault"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(970,1570)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(2220,1410)" name="Multiplexer">
-      <a name="facing" val="west"/>
-      <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="4" loc="(180,1420)" name="D Flip-Flop">
-      <a name="trigger" val="low"/>
-    </comp>
-    <comp lib="0" loc="(360,1450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2300,1650)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="imm6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1830,650)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="0"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-    </comp>
-    <comp lib="1" loc="(510,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1530,820)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(220,700)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="r5"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1990,930)" name="Multiplexer">
-      <a name="select" val="3"/>
-      <a name="width" val="4"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(1570,960)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(1760,1320)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1710,1250)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(220,1110)" name="Register">
-      <a name="width" val="6"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="1" loc="(2360,1670)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1250,980)" name="Tunnel">
-      <a name="label" val="imm9"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1070,430)" name="Tunnel">
-      <a name="label" val="fp_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(570,1580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="direct_exc_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(660,1630)" name="Tunnel">
-      <a name="label" val="latch_double_fault"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1740,1080)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="imm6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1160,1470)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="X"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(150,1240)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="int_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1150)" name="Tunnel">
-      <a name="label" val="r_asrt1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1080,960)" name="Decoder">
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(220,730)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="r6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(880,1500)" name="Constant">
-      <a name="width" val="16"/>
-      <a name="value" val="0x8200"/>
-    </comp>
-    <comp lib="0" loc="(2210,1490)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rs0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(320,1800)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2060,610)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="io_phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(420,1260)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_trig_sp"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(140,1110)" name="Pin">
-      <a name="width" val="6"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="exc_vec"/>
-    </comp>
-    <comp lib="0" loc="(2350,1600)" name="Tunnel">
+    <comp lib="0" loc="(1690,1210)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="alu2"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2690,1350)" name="Tunnel">
-      <a name="label" val="word"/>
+    <comp lib="0" loc="(2690,1050)" name="Tunnel">
+      <a name="label" val="pc_latch"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(360,880)" name="Tunnel">
+    <comp lib="0" loc="(930,1820)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="r_latch"/>
+      <a name="label" val="virtual_instruction"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1540,820)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="1"/>
-      <a name="bit3" val="2"/>
-    </comp>
-    <comp lib="2" loc="(1980,800)" name="Decoder">
-      <a name="selloc" val="tr"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="1" loc="(2340,1210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1880,990)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1210,780)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Y"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1900,730)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="control" val="left"/>
-    </comp>
-    <comp lib="0" loc="(2370,1730)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x6"/>
-    </comp>
-    <comp lib="1" loc="(1390,990)" name="NOT Gate">
+    <comp lib="1" loc="(450,1220)" name="OR Gate">
       <a name="facing" val="north"/>
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(2150,950)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1740,1100)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="imm9"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(220,430)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="sp_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(635,1119)" name="Text">
-      <a name="text" val="1"/>
-    </comp>
-    <comp lib="0" loc="(780,1780)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(380,1510)" name="Tunnel">
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1640,470)" name="Tunnel">
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(910,450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rs0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1260,940)" name="Tunnel">
-      <a name="label" val="alu2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1740,1000)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="0op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1430,740)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="sp_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1880,910)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1360,490)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="16"/>
-    </comp>
-    <comp lib="1" loc="(480,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="1" loc="(940,1610)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(950,1550)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2230,970)" name="Tunnel">
-      <a name="label" val="exc_trig_pc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(800,1290)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(1640,920)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(120,1570)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="halt"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1290)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_rel_n"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1330)" name="Tunnel">
-      <a name="label" val="sp_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1130)" name="Tunnel">
-      <a name="label" val="r_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(690,1340)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="reset_exc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2350,1580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(660,1130)" name="Tunnel">
-      <a name="label" val="rti"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(655,1176)" name="Text">
-      <a name="text" val="int, reset, rti"/>
-    </comp>
-    <comp lib="1" loc="(570,1140)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1350,1350)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="6"/>
-      <a name="incoming" val="6"/>
-    </comp>
-    <comp lib="1" loc="(450,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(2230,1160)" name="ROM">
-      <a name="addrWidth" val="10"/>
-      <a name="dataWidth" val="28"/>
-      <a name="contents">addr/data: 10 28
-4*8000400 4*c000000 4a00282 5280082 4a00282 5280082 4e00082 4280082
-4a01082 5280082 4a20082 5280082 c080580 4a00282 400000 20000
-1000 20000 200 20000 210001 5*8000400 8001 15*8000400
-c088482 8088482 8188482 c088480 8088480 8188480 c028482 8028482
-8*8000400 c0804ce c0804ee 808048e 80804ae 818048e 81804ae c0204ce
-c0204ee 802048e 80204ae 8000410 8000430 800a409 800a429 8008408
-8008428 4a01082 4080088 4a00092 4a000b2 8200449 8200469 4a00282
-4a00282 8*8000400 c098482 8098482 8198482 c098480 8098480 8198480
-c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
-8000569 8000400 c080180 8*0 8*8000400 4080180 5280082 9000400
-8800400 9000400 8000400 9000400 8800400 9000400 8800400 8000400
-20000 60*8000400 4a00282 4080088 9000400 9000400 8000400 8000400
-149 169 32*8000400 8*0 8*8000400 9000400 800000 9*8000400
-9000400 60*8000400 4080088 5*8000400 9000400 9000400 32*8000400 8*0
-9*8000400 8800400 70*8000400 4080088 39*8000400 8*0 80*8000400 1000000
-39*8000400 8*0 80*8000400 9000400 39*8000400 8*0 120*8000400 8*0
-120*8000400
-</a>
-    </comp>
-    <comp lib="0" loc="(1350,1350)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="imm6_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(2180,750)" name="bus_control">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1410,1020)" name="Tunnel">
-      <a name="label" val="br_abs"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(180,1580)" name="S-R Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="1" loc="(540,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="2" loc="(1840,1060)" name="Priority Encoder"/>
-    <comp loc="(1580,500)" name="alu"/>
-    <comp lib="0" loc="(1600,570)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-    </comp>
-    <comp lib="0" loc="(1350,1630)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(130,760)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="FP"/>
-    </comp>
-    <comp lib="0" loc="(1000,400)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="label" val="bus0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1630,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1260,840)" name="Tunnel">
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(230,1520)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2190,1380)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3_ind"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1220,460)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="sp_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1450,490)" name="Tunnel">
-      <a name="label" val="pc_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2000,830)" name="Tunnel">
-      <a name="label" val="rti"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1470,530)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_rel_nop"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(170,1770)" name="Counter">
-      <a name="width" val="3"/>
-      <a name="max" val="0x7"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(340,1700)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2310,1690)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="3"/>
     </comp>
-    <comp lib="0" loc="(830,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="fp"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1770,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ps_latch_flags"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(860,1820)" name="Tunnel">
-      <a name="label" val="reset_exc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1130,480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="busD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(940,710)" name="Tunnel">
-      <a name="label" val="r_asrt1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="3" loc="(620,1440)" name="Comparator">
-      <a name="width" val="3"/>
-      <a name="mode" val="unsigned"/>
-    </comp>
-    <comp lib="0" loc="(1920,1100)" name="Bit Extender">
-      <a name="in_width" val="3"/>
-      <a name="out_width" val="4"/>
-    </comp>
-    <comp lib="1" loc="(1520,1110)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2210,1450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rd"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1880,950)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2010,1110)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-    </comp>
-    <comp lib="0" loc="(220,610)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="r2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1530,720)" name="Tunnel">
+    <comp lib="5" loc="(1830,540)" name="LED">
       <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="label" val="pc_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(120,1670)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2270,1400)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rs1_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1160,1540)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-    </comp>
-    <comp lib="0" loc="(800,1830)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(1360,512)" name="Text">
-      <a name="text" val="PС"/>
-      <a name="font" val="SansSerif bold 20"/>
-    </comp>
-    <comp lib="0" loc="(2370,1710)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x5"/>
-    </comp>
-    <comp lib="1" loc="(630,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(2280,890)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(570,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(230,1160)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="direct_exc_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1580,1610)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="9"/>
-      <a name="label" val="imm9_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(810,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(720,1520)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1440,970)" name="Tunnel">
-      <a name="label" val="br_abs_nop"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(2030,1440)" name="Multiplexer">
-      <a name="width" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1510,920)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(190,1070)" name="Tunnel">
-      <a name="label" val="exc_trig_ext"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(120,1690)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(370,760)" name="Pull Resistor">
-      <a name="facing" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1920,650)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="ps_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2150,980)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="28"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="0"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-      <a name="bit16" val="none"/>
-      <a name="bit17" val="none"/>
-      <a name="bit18" val="none"/>
-      <a name="bit19" val="none"/>
-      <a name="bit20" val="none"/>
-      <a name="bit21" val="none"/>
-      <a name="bit22" val="none"/>
-      <a name="bit23" val="none"/>
-      <a name="bit24" val="none"/>
-      <a name="bit25" val="none"/>
-      <a name="bit26" val="none"/>
-      <a name="bit27" val="none"/>
-    </comp>
-    <comp lib="1" loc="(630,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(120,1500)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="wait"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1170)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_abs"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1700,910)" name="Tunnel">
-      <a name="label" val="di"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1860,650)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="0"/>
-    </comp>
-    <comp lib="0" loc="(1750,640)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="CVZN"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(720,1400)" name="Bit Extender">
-      <a name="in_width" val="6"/>
-    </comp>
-    <comp lib="0" loc="(1280,1330)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="fanout" val="9"/>
-      <a name="incoming" val="9"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="1" loc="(1060,420)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1740,1060)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="mem2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(570,1430)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="exc_internal_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(340,1790)" name="Tunnel">
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1740,670)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="ei"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,910)" name="Tunnel">
-      <a name="label" val="imm_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(150,1200)" name="Tunnel">
-      <a name="label" val="irq"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2240,770)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="data_in"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(1390,1170)" name="NOT Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(1350,1590)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1420,460)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="pc_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2260,1690)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(840,1710)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="6" loc="(441,1585)" name="Text">
-      <a name="text" val="3 - fault"/>
-    </comp>
-    <comp lib="0" loc="(140,1770)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(1990,1450)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1900,1480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,970)" name="Tunnel">
-      <a name="label" val="mem"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1790,490)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="label" val="busA"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1200,930)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="2"/>
-      <a name="label" val="XY"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(1789,595)" name="Text">
-      <a name="text" val="CVZN"/>
-    </comp>
-    <comp lib="2" loc="(1180,900)" name="Demultiplexer">
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(2130,1640)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1250,860)" name="Tunnel">
-      <a name="label" val="1op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2210,830)" name="Tunnel">
-      <a name="label" val="io_phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1980,1420)" name="Constant">
-      <a name="width" val="3"/>
-    </comp>
-    <comp lib="4" loc="(250,1810)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(1660,520)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(220,550)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="r0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,830)" name="Tunnel">
-      <a name="label" val="alu_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1900,810)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(1900,1450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1840,1220)" name="Priority Encoder"/>
-    <comp lib="2" loc="(1750,1660)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(460,1140)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(530,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="1" loc="(1200,420)" name="Controlled Buffer">
-      <a name="facing" val="north"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="2" loc="(2310,1070)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="28"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(1060,740)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="control" val="left"/>
-    </comp>
-    <comp lib="4" loc="(660,1250)" name="Register">
-      <a name="width" val="3"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="2" loc="(2450,1790)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1000,750)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="label" val="busD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(370,410)" name="Pull Resistor">
-      <a name="facing" val="east"/>
-    </comp>
-    <comp lib="1" loc="(390,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(2110,760)" name="Controlled Buffer">
-      <a name="facing" val="west"/>
-      <a name="width" val="16"/>
-      <a name="control" val="left"/>
-    </comp>
-    <comp lib="1" loc="(1430,1060)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="4" loc="(410,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="1" loc="(1610,960)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(470,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="r1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(1552,792)" name="Text">
-      <a name="text" val="int, reset"/>
-    </comp>
-    <comp lib="6" loc="(501,1190)" name="Text">
-      <a name="text" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1680,1680)" name="Bit Extender">
-      <a name="in_width" val="6"/>
-    </comp>
-    <comp lib="6" loc="(450,1547)" name="Text">
-      <a name="text" val="0 - running"/>
-    </comp>
-    <comp lib="1" loc="(1370,1200)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1350,570)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="pc_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(1260,1210)" name="branch_logic">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1130,1430)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="2"/>
-      <a name="label" val="XY"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(150,1790)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1860,670)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="int_en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2350,1620)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3_ind"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2010,1030)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(2690,850)" name="Tunnel">
-      <a name="label" val="data"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(1790,670)" name="ps_register">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="2" loc="(1200,810)" name="Demultiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(440,1460)" name="Tunnel">
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1590,450)" name="Multiplexer">
-      <a name="facing" val="west"/>
-      <a name="selloc" val="tr"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(940,1470)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1690,430)" name="Tunnel">
-      <a name="label" val="mem"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(220,490)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="ps_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(610,1240)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(130,640)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R3"/>
-    </comp>
-    <comp lib="0" loc="(2690,1190)" name="Tunnel">
-      <a name="label" val="r_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(750,1730)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="irq"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2220,970)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(3970,2520)" name="Ground"/>
-    <comp lib="0" loc="(710,1550)" name="Tunnel">
-      <a name="label" val="exc_trig_ext"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(370,590)" name="Pull Resistor">
-      <a name="facing" val="east"/>
-    </comp>
-    <comp lib="0" loc="(2050,1730)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="3"/>
-      <a name="label" val="phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1370,1020)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(810,1290)" name="Tunnel">
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1190,1230)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="ps_flags"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1700,850)" name="Tunnel">
-      <a name="label" val="halt"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1210,1170)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="br_abs_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(670,1510)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(2360,1090)" name="Multiplexer">
-      <a name="width" val="28"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(840,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1160,1450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Y"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1270)" name="Tunnel">
-      <a name="label" val="sp_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1350,1470)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rs0_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1110)" name="Tunnel">
-      <a name="label" val="ps_latch_word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(980,1600)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1370,820)" name="Tunnel">
-      <a name="label" val="br_abs_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1880,870)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1120,1570)" name="Tunnel">
       <a name="facing" val="east"/>
@@ -2928,15 +1663,75 @@ c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
       <a name="label" val="op_type_d3"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="6" loc="(447,1560)" name="Text">
-      <a name="text" val="1 - waiting"/>
+    <comp lib="1" loc="(2420,1610)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(1970,500)" name="Pin">
-      <a name="facing" val="west"/>
+    <comp lib="1" loc="(810,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1680,1720)" name="Bit Extender">
+      <a name="in_width" val="6"/>
+      <a name="type" val="one"/>
+    </comp>
+    <comp lib="0" loc="(1130,1430)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="2"/>
+      <a name="label" val="XY"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(750,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1140,1400)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1000,400)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="label" val="bus0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(230,1160)" name="Tunnel">
+      <a name="width" val="6"/>
+      <a name="label" val="direct_exc_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(831,1138)" name="Text">
+      <a name="text" val="3. Mutiple exceptions across several phases"/>
+    </comp>
+    <comp lib="0" loc="(210,550)" name="Pin">
       <a name="output" val="true"/>
       <a name="width" val="16"/>
-      <a name="label" val="address"/>
-      <a name="labelloc" val="east"/>
+      <a name="label" val="R0"/>
+    </comp>
+    <comp lib="3" loc="(1060,1510)" name="Comparator">
+      <a name="width" val="16"/>
+      <a name="mode" val="unsigned"/>
+    </comp>
+    <comp lib="6" loc="(2050,1766)" name="Text">
+      <a name="text" val="1, 3, 5, 7"/>
+    </comp>
+    <comp lib="1" loc="(2340,1120)" name="OR Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(1350,1630)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="1" loc="(1430,1150)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(2150,920)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -2971,155 +1766,120 @@ c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
       <a name="bit26" val="none"/>
       <a name="bit27" val="none"/>
     </comp>
-    <comp lib="0" loc="(1740,1740)" name="Tunnel">
-      <a name="label" val="imm6"/>
+    <comp lib="0" loc="(2690,1290)" name="Tunnel">
+      <a name="label" val="sp_dec"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="4" loc="(430,1690)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(2690,1310)" name="Tunnel">
-      <a name="label" val="sp_inc"/>
+    <comp lib="0" loc="(2690,1070)" name="Tunnel">
+      <a name="label" val="ps_asrtD"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1810,720)" name="Tunnel">
-      <a name="label" val="ps_latch_word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1650,960)" name="NOT Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(910,720)" name="Tunnel">
-      <a name="facing" val="east"/>
+    <comp lib="0" loc="(2270,1480)" name="Tunnel">
       <a name="width" val="3"/>
-      <a name="label" val="rs1"/>
+      <a name="label" val="rs0_d"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1260,880)" name="Tunnel">
-      <a name="label" val="2op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2410,1780)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_d1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(1000,1540)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(1440,720)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-      <a name="label" val="sp_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1700,870)" name="Tunnel">
-      <a name="label" val="wait"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(470,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(2690,890)" name="Tunnel">
-      <a name="label" val="imm_asrt1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2020,1710)" name="OR Gate">
-      <a name="width" val="16"/>
+    <comp lib="1" loc="(930,1710)" name="OR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(1350,1470)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="1" loc="(2230,1370)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(220,670)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="r4"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,1810)" name="Tunnel">
+    <comp lib="0" loc="(120,1650)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
+      <a name="label" val="critical_fault"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(390,1450)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(2320,1100)" name="Constant">
-      <a name="width" val="28"/>
-      <a name="value" val="0x8000000"/>
-    </comp>
-    <comp lib="0" loc="(1790,810)" name="Tunnel">
+    <comp lib="0" loc="(1510,920)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="width" val="4"/>
       <a name="label" val="op_type_d0"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2690,950)" name="Tunnel">
-      <a name="label" val="imm_shift"/>
+    <comp lib="0" loc="(2000,830)" name="Tunnel">
+      <a name="label" val="rti"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2300,1040)" name="Tunnel">
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(1790,673)" name="Text">
-      <a name="text" val="PS"/>
-      <a name="font" val="SansSerif bold 20"/>
-    </comp>
-    <comp lib="0" loc="(1980,1720)" name="Constant">
-      <a name="width" val="16"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="1" loc="(1860,800)" name="OR Gate">
+    <comp lib="1" loc="(1660,810)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(220,760)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="fp"/>
+    <comp lib="0" loc="(1790,620)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="labelfont" val="SansSerif plain 16"/>
+    </comp>
+    <comp lib="0" loc="(340,820)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(600,1210)" name="Tunnel">
-      <a name="label" val="latch_double_fault"/>
+    <comp lib="0" loc="(1890,840)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="0op"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(350,1490)" name="AND Gate">
+    <comp lib="1" loc="(2420,1570)" name="OR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="1" loc="(130,1780)" name="NOT Gate">
-      <a name="size" val="20"/>
+    <comp lib="1" loc="(510,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(2690,1250)" name="Tunnel">
-      <a name="label" val="sp_asrt0"/>
+    <comp lib="4" loc="(2230,1160)" name="ROM">
+      <a name="addrWidth" val="10"/>
+      <a name="dataWidth" val="28"/>
+      <a name="contents">addr/data: 10 28
+4*8000400 4*c000000 4a00282 5280082 4a00282 5280082 4e00082 4280082
+4a01082 5280082 4a20082 5280082 c080580 4a00282 400000 20000
+1000 20000 200 20000 210001 5*8000400 8001 15*8000400
+c088482 8088482 8188482 c088480 8088480 8188480 c028482 8028482
+8*8000400 c0804ce c0804ee 808048e 80804ae 818048e 81804ae c0204ce
+c0204ee 802048e 80204ae 8000410 8000430 800a409 800a429 8008408
+8008428 4a01082 4080088 4a00092 4a000b2 8200449 8200469 4a00282
+4a00282 8*8000400 c098482 8098482 8198482 c098480 8098480 8198480
+c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
+8000569 8000400 c080180 8*0 8*8000400 4080180 5280082 9000400
+8800400 9000400 8000400 9000400 8800400 9000400 8800400 8000400
+20000 60*8000400 4a00282 4080088 9000400 9000400 8000400 8000400
+149 169 32*8000400 8*0 8*8000400 9000400 800000 9*8000400
+9000400 60*8000400 4080088 5*8000400 9000400 9000400 32*8000400 8*0
+9*8000400 8800400 70*8000400 4080088 39*8000400 8*0 80*8000400 1000000
+39*8000400 8*0 80*8000400 9000400 39*8000400 8*0 120*8000400 8*0
+120*8000400
+</a>
+    </comp>
+    <comp lib="0" loc="(1740,1720)" name="Tunnel">
+      <a name="label" val="imm_extend_negative"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1370,1420)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rs1_d"/>
+    <comp lib="0" loc="(220,430)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="sp_value"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1140,1400)" name="Tunnel">
+    <comp lib="0" loc="(1860,1410)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_d1"/>
+      <a name="label" val="alu3"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1860,1430)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3_ind"/>
+    <comp lib="0" loc="(1830,540)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(810,1320)" name="Tunnel">
+      <a name="label" val="exc_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(180,1420)" name="D Flip-Flop">
+      <a name="trigger" val="low"/>
+    </comp>
+    <comp lib="1" loc="(270,1500)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(1690,430)" name="Tunnel">
+      <a name="label" val="mem"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1740,1040)" name="Tunnel">
@@ -3127,21 +1887,107 @@ c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
       <a name="label" val="2op"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2210,660)" name="Tunnel">
-      <a name="label" val="word"/>
+    <comp lib="0" loc="(1270,800)" name="Tunnel">
+      <a name="label" val="0op"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1370,1440)" name="Tunnel">
+    <comp lib="0" loc="(2690,1130)" name="Tunnel">
+      <a name="label" val="r_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(610,1240)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(2110,1660)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(970,1810)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(2350,1600)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1710,1270)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_rel_p"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(890,1460)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1660,540)" name="Tunnel">
       <a name="width" val="3"/>
       <a name="label" val="shift_count_d"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2290,890)" name="Tunnel">
-      <a name="label" val="exc_trig_invalid_inst"/>
+    <comp lib="6" loc="(1282,702)" name="Text">
+      <a name="text" val="2023"/>
+      <a name="font" val="SansSerif bolditalic 16"/>
+    </comp>
+    <comp lib="0" loc="(130,580)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R1"/>
+    </comp>
+    <comp lib="1" loc="(450,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1820,630)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="ps_flags"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2690,1090)" name="Tunnel">
-      <a name="label" val="ps_latch_flags"/>
+    <comp lib="2" loc="(1230,1200)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="4"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(200,1130)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(140,1110)" name="Pin">
+      <a name="width" val="6"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="exc_vec"/>
+    </comp>
+    <comp lib="1" loc="(1370,1110)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(760,1210)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="double_fault"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,900)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1370,820)" name="Tunnel">
+      <a name="label" val="br_abs_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(570,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2060,610)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="io_phase"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(2210,510)" name="Pin">
@@ -3150,248 +1996,11 @@ c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
       <a name="label" val="mem"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(2050,1730)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-    </comp>
-    <comp lib="2" loc="(2070,1690)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="1" loc="(2180,610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(210,430)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="SP"/>
-    </comp>
-    <comp lib="0" loc="(340,1720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="CUT"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1170)" name="Tunnel">
-      <a name="label" val="r_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2460,1560)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="arith_carry"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1680,1630)" name="Bit Extender">
-      <a name="in_width" val="9"/>
-      <a name="type" val="one"/>
-    </comp>
-    <comp lib="0" loc="(1740,1720)" name="Tunnel">
-      <a name="label" val="imm_extend_negative"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(2410,1720)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2130,860)" name="Constant">
-      <a name="width" val="28"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(1350,1500)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(260,990)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rd"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(750,1750)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="int_en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="3" loc="(1930,1700)" name="Shifter">
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1690,450)" name="Tunnel">
-      <a name="label" val="inc_address"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1520,920)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1200,520)" name="Tunnel">
-      <a name="label" val="sp_dec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(800,1480)" name="Constant">
-      <a name="width" val="16"/>
-      <a name="value" val="0x8000"/>
-    </comp>
-    <comp lib="1" loc="(2220,930)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2530,1780)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="alu_func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1710,1350)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="fetch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,730)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R6"/>
-    </comp>
-    <comp lib="0" loc="(1270,800)" name="Tunnel">
-      <a name="label" val="0op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(420,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1680,1720)" name="Bit Extender">
-      <a name="in_width" val="6"/>
-      <a name="type" val="one"/>
-    </comp>
-    <comp lib="0" loc="(2690,1010)" name="Tunnel">
-      <a name="label" val="pc_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(570,1530)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="exc_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2210,530)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="data/ins'"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1910,1620)" name="Constant">
-      <a name="width" val="4"/>
-    </comp>
-    <comp lib="0" loc="(1880,970)" name="Tunnel">
+    <comp lib="0" loc="(2260,1690)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="width" val="4"/>
       <a name="label" val="op_type_d3"/>
       <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1660,810)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(140,1200)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="IRQ"/>
-    </comp>
-    <comp lib="0" loc="(140,1240)" name="Pin">
-      <a name="width" val="6"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="int_vec"/>
-    </comp>
-    <comp lib="0" loc="(2690,1290)" name="Tunnel">
-      <a name="label" val="sp_dec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(220,460)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="pc_value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1440,750)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(210,610)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R2"/>
-    </comp>
-    <comp lib="0" loc="(340,820)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="3" loc="(2180,870)" name="Comparator">
-      <a name="width" val="28"/>
-    </comp>
-    <comp lib="0" loc="(120,1610)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(570,1620)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="0" loc="(1320,520)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="pc_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(640,1270)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(450,1710)" name="Tunnel">
-      <a name="label" val="startup"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(1278,659)" name="Text">
-      <a name="text" val="Coco-de-Mer 16"/>
-      <a name="font" val="SansSerif bolditalic 28"/>
-    </comp>
-    <comp lib="0" loc="(940,460)" name="Tunnel">
-      <a name="label" val="r_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(130,700)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R5"/>
-    </comp>
-    <comp lib="0" loc="(120,1590)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(790,1740)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2210,1410)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="rs1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(520,1210)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(1590,820)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
     </comp>
     <comp lib="0" loc="(2260,1690)" name="Splitter">
       <a name="fanout" val="3"/>
@@ -3402,49 +2011,189 @@ c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
       <a name="bit2" val="1"/>
       <a name="bit3" val="2"/>
     </comp>
-    <comp lib="0" loc="(120,1650)" name="Tunnel">
+    <comp lib="0" loc="(1350,1440)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1980,1420)" name="Constant">
+      <a name="width" val="3"/>
+    </comp>
+    <comp lib="0" loc="(120,1570)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="critical_fault"/>
+      <a name="label" val="halt"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1790,720)" name="Tunnel">
+    <comp lib="0" loc="(1790,810)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(530,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(150,1790)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="clk"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1410,1110)" name="Tunnel">
-      <a name="label" val="br_rel_n"/>
+    <comp lib="1" loc="(1440,750)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(2690,870)" name="Tunnel">
+      <a name="label" val="fp_asrt0"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(810,1220)" name="Tunnel">
-      <a name="label" val="critical_fault"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="1" loc="(690,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(420,1280)" name="Tunnel">
+    <comp lib="0" loc="(360,990)" name="Tunnel">
       <a name="facing" val="east"/>
+      <a name="label" val="r_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1260,900)" name="Tunnel">
+      <a name="label" val="alu3_ind"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(130,460)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="PC"/>
+    </comp>
+    <comp lib="0" loc="(120,1440)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="hold"/>
+    </comp>
+    <comp lib="0" loc="(360,880)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="r_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,810)" name="Tunnel">
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1450,510)" name="NOT Gate">
+      <a name="facing" val="west"/>
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(1370,1570)" name="Tunnel">
+      <a name="width" val="4"/>
+      <a name="label" val="br_abs_flags_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(640,1770)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1790,540)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="int_en"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(620,1620)" name="Bit Extender">
+      <a name="in_width" val="3"/>
+    </comp>
+    <comp lib="0" loc="(2350,1560)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(390,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1690,450)" name="Tunnel">
+      <a name="label" val="inc_address"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(470,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="r1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(310,1500)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(2000,1630)" name="Tunnel">
+      <a name="label" val="imm_shift"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1350,1470)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(870,1430)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="latch_int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,530)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="data/ins'"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="2" loc="(530,1290)" name="Priority Encoder"/>
+    <comp lib="0" loc="(2230,970)" name="Tunnel">
       <a name="label" val="exc_trig_pc"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2690,1210)" name="Tunnel">
-      <a name="label" val="read"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="1" loc="(1650,960)" name="NOT Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="20"/>
     </comp>
-    <comp lib="2" loc="(340,1560)" name="Priority Encoder">
-      <a name="select" val="2"/>
+    <comp lib="1" loc="(840,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
     </comp>
-    <comp lib="0" loc="(1140,1630)" name="Splitter">
+    <comp lib="0" loc="(2010,1030)" name="Splitter">
       <a name="fanout" val="4"/>
       <a name="incoming" val="4"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="1" loc="(840,1470)" name="OR Gate">
+    <comp lib="0" loc="(970,1470)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="fetched_instruction"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(810,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1550,500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="alu_func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2020,1710)" name="OR Gate">
       <a name="width" val="16"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(2190,530)" name="Tunnel">
+    <comp lib="0" loc="(1130,510)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="data"/>
+      <a name="label" val="sp_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(150,1240)" name="Tunnel">
+      <a name="width" val="6"/>
+      <a name="label" val="int_vec"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="1" loc="(690,1030)" name="AND Gate">
@@ -3452,10 +2201,1343 @@ c038482 8038482 8*8000400 c080580 8008401 8018400 8018401 8000549
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
+    <comp lib="1" loc="(420,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1360,490)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="16"/>
+    </comp>
+    <comp lib="0" loc="(220,640)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="r3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1310)" name="Tunnel">
+      <a name="label" val="sp_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(220,490)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="ps_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1680,1680)" name="Bit Extender">
+      <a name="in_width" val="6"/>
+    </comp>
+    <comp lib="0" loc="(1880,870)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,890)" name="Tunnel">
+      <a name="label" val="imm_asrt1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1610,960)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(140,1070)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="EXC"/>
+    </comp>
+    <comp lib="6" loc="(446,1572)" name="Text">
+      <a name="text" val="2 - halted"/>
+    </comp>
+    <comp lib="1" loc="(270,1770)" name="NOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(930,1800)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_rel_nop"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1750,640)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="CVZN"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(380,1690)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(220,1110)" name="Register">
+      <a name="width" val="6"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="1" loc="(1390,1080)" name="NOT Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(1660,520)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2010,1060)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(120,1690)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(1740,690)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="di"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1350,1500)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rd_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1350)" name="Tunnel">
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2100,620)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="6" loc="(635,1119)" name="Text">
+      <a name="text" val="1"/>
+    </comp>
+    <comp lib="1" loc="(540,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1130,1630)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1580,420)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="arith_carry"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(120,1380)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="clock"/>
+    </comp>
+    <comp lib="0" loc="(1600,580)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="0"/>
+    </comp>
+    <comp lib="0" loc="(2690,1010)" name="Tunnel">
+      <a name="label" val="pc_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(980,1690)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(950,1550)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,850)" name="Tunnel">
+      <a name="label" val="data"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1880,990)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(2520,1780)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1070,430)" name="Tunnel">
+      <a name="label" val="fp_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2410,1800)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_d0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2010,1130)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="3"/>
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1200,930)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="2"/>
+      <a name="label" val="XY"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(630,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2300,1220)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2040,1440)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(590,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="r3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1880,950)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(570,1450)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x7"/>
+    </comp>
+    <comp lib="3" loc="(1930,1700)" name="Shifter">
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(210,1810)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(430,1460)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(1650,900)" name="Decoder">
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(970,1570)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2300,1040)" name="Tunnel">
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2140,620)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(610,1720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="irq"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1140,1430)" name="Splitter">
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1700,890)" name="Tunnel">
+      <a name="label" val="ei"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1410,1110)" name="Tunnel">
+      <a name="label" val="br_rel_n"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(530,1150)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2130,860)" name="Constant">
+      <a name="width" val="28"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp loc="(1580,500)" name="alu"/>
+    <comp lib="0" loc="(2150,950)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+    </comp>
+    <comp lib="0" loc="(2690,1330)" name="Tunnel">
+      <a name="label" val="sp_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1220,460)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="sp_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(220,580)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="r1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1180,900)" name="Demultiplexer">
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(220,670)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="r4"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1710,1350)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1430,970)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1900,730)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="control" val="left"/>
+    </comp>
+    <comp lib="0" loc="(660,1130)" name="Tunnel">
+      <a name="label" val="rti"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2120,770)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="read"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,490)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="PS"/>
+    </comp>
+    <comp lib="0" loc="(1740,1000)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="0op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1350,1350)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="6"/>
+      <a name="incoming" val="6"/>
+    </comp>
+    <comp lib="0" loc="(130,760)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="FP"/>
+    </comp>
+    <comp lib="6" loc="(1360,512)" name="Text">
+      <a name="text" val="PС"/>
+      <a name="font" val="SansSerif bold 20"/>
+    </comp>
+    <comp lib="0" loc="(1740,1740)" name="Tunnel">
+      <a name="label" val="imm6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(230,1520)" name="OR Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
     <comp lib="0" loc="(1560,980)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="0op"/>
       <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(2010,1590)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(120,1670)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1090)" name="Tunnel">
+      <a name="label" val="ps_latch_flags"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1880,910)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(830,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp loc="(1360,500)" name="pc_register">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(2210,680)" name="Tunnel">
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1140,1630)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(2150,980)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="28"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="0"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+      <a name="bit16" val="none"/>
+      <a name="bit17" val="none"/>
+      <a name="bit18" val="none"/>
+      <a name="bit19" val="none"/>
+      <a name="bit20" val="none"/>
+      <a name="bit21" val="none"/>
+      <a name="bit22" val="none"/>
+      <a name="bit23" val="none"/>
+      <a name="bit24" val="none"/>
+      <a name="bit25" val="none"/>
+      <a name="bit26" val="none"/>
+      <a name="bit27" val="none"/>
+    </comp>
+    <comp lib="0" loc="(1410,1020)" name="Tunnel">
+      <a name="label" val="br_abs"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(880,1500)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0x8200"/>
+    </comp>
+    <comp lib="1" loc="(320,1800)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(940,1610)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="6" loc="(1278,659)" name="Text">
+      <a name="text" val="Coco-de-Mer 16"/>
+      <a name="font" val="SansSerif bolditalic 28"/>
+    </comp>
+    <comp lib="0" loc="(600,1210)" name="Tunnel">
+      <a name="label" val="latch_double_fault"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1700,870)" name="Tunnel">
+      <a name="label" val="wait"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(3970,2520)" name="Ground"/>
+    <comp lib="0" loc="(2690,1190)" name="Tunnel">
+      <a name="label" val="r_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1160,1470)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="X"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1620,800)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="imm9"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(660,1630)" name="Tunnel">
+      <a name="label" val="latch_double_fault"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(770,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="r6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1160,1540)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+    </comp>
+    <comp lib="0" loc="(660,1150)" name="Tunnel">
+      <a name="label" val="int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(800,1480)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0x8000"/>
+    </comp>
+    <comp lib="1" loc="(720,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1560,910)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1280,1330)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="fanout" val="9"/>
+      <a name="incoming" val="9"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1900,1480)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,1400)" name="Bit Extender">
+      <a name="in_width" val="6"/>
+    </comp>
+    <comp lib="2" loc="(2450,1790)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(340,1560)" name="Priority Encoder">
+      <a name="select" val="2"/>
+    </comp>
+    <comp lib="6" loc="(551,1117)" name="Text">
+      <a name="text" val="3"/>
+    </comp>
+    <comp lib="0" loc="(1440,720)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="label" val="sp_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(450,1710)" name="Tunnel">
+      <a name="label" val="startup"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1280,1320)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="9"/>
+      <a name="label" val="imm9_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1200,420)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1060,450)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+      <a name="label" val="fp"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1150,520)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1000,750)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="label" val="busD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(700,1320)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,550)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="rd/wr'"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1590,600)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="cout"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1370,1420)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rs1_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1580,1610)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="9"/>
+      <a name="label" val="imm9_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(441,1585)" name="Text">
+      <a name="text" val="3 - fault"/>
+    </comp>
+    <comp lib="0" loc="(340,1810)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="fetch"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(2190,550)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="read"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1750,1660)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(570,1580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="direct_exc_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1270)" name="Tunnel">
+      <a name="label" val="sp_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(2360,1090)" name="Multiplexer">
+      <a name="width" val="28"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1080,670)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="imm"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(220,610)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="r2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1190,1230)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="ps_flags"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(620,1140)" name="OR Gate">
+      <a name="facing" val="west"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1220,430)" name="Tunnel">
+      <a name="label" val="sp_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1530,1110)" name="Tunnel">
+      <a name="label" val="br_rel_nop"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,1760)" name="Tunnel">
+      <a name="label" val="latch_int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(450,1547)" name="Text">
+      <a name="text" val="0 - running"/>
+    </comp>
+    <comp lib="0" loc="(1440,970)" name="Tunnel">
+      <a name="label" val="br_abs_nop"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1060,420)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(2500,1650)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2690,990)" name="Tunnel">
+      <a name="label" val="pc_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2370,1730)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x6"/>
+    </comp>
+    <comp lib="0" loc="(2320,1100)" name="Constant">
+      <a name="width" val="28"/>
+      <a name="value" val="0x8000000"/>
+    </comp>
+    <comp lib="0" loc="(1810,720)" name="Tunnel">
+      <a name="label" val="ps_latch_word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(460,1140)" name="OR Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(210,610)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R2"/>
+    </comp>
+    <comp lib="4" loc="(750,1310)" name="S-R Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1260,840)" name="Tunnel">
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1790,490)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="label" val="busA"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1900,810)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(1350,1470)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rs0_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1880,1710)" name="Constant">
+      <a name="width" val="4"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(210,1770)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(2210,660)" name="Tunnel">
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(660,1820)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1910,1620)" name="Constant">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="1" loc="(2220,930)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1730,1200)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1140,1590)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(670,1400)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="int_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2000,810)" name="Tunnel">
+      <a name="label" val="jsr"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1520,1110)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(1840,1060)" name="Priority Encoder"/>
+    <comp lib="0" loc="(930,1680)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2140,700)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="sign_extend"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2300,1160)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="0"/>
+    </comp>
+    <comp lib="1" loc="(1530,750)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(1400,420)" name="Controlled Buffer">
+      <a name="facing" val="north"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(220,700)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="r5"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(370,590)" name="Pull Resistor">
+      <a name="facing" val="east"/>
+    </comp>
+    <comp lib="0" loc="(940,460)" name="Tunnel">
+      <a name="label" val="r_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,830)" name="Tunnel">
+      <a name="label" val="alu_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(940,510)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="select" val="3"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(2210,830)" name="Tunnel">
+      <a name="label" val="io_phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2190,510)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="mem"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1880,540)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(890,1700)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="latch_int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2140,680)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
+    </comp>
+    <comp lib="2" loc="(1990,930)" name="Multiplexer">
+      <a name="select" val="3"/>
+      <a name="width" val="4"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1670,810)" name="Tunnel">
+      <a name="label" val="int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(470,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1830,670)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(650,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="r4"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2340,1210)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1860,800)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(340,1790)" name="Tunnel">
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1370,1020)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(570,1620)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="1" loc="(750,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1810,780)" name="Splitter">
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+    </comp>
+    <comp lib="4" loc="(770,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1140,1500)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(2690,1150)" name="Tunnel">
+      <a name="label" val="r_asrt1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2050,1060)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="10"/>
+      <a name="incoming" val="10"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(720,1810)" name="Tunnel">
+      <a name="label" val="reset_exc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(150,1200)" name="Tunnel">
+      <a name="label" val="irq"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(810,1290)" name="Tunnel">
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(640,1270)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1330,480)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="busD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(1790,670)" name="ps_register">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="5" loc="(1880,540)" name="LED">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="6" loc="(754,1100)" name="Text">
+      <a name="text" val="Double fault: 1. Unrecoverable instruction"/>
+    </comp>
+    <comp lib="0" loc="(2270,1400)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rs1_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(140,1770)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(1370,1400)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_d0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(220,760)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="fp"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2240,720)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="data_out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="2" loc="(940,660)" name="Multiplexer">
+      <a name="select" val="3"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(360,1590)" name="Tunnel">
+      <a name="width" val="2"/>
+      <a name="label" val="status"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1080,620)" name="Tunnel">
+      <a name="label" val="imm_asrt1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(980,1810)" name="Tunnel">
+      <a name="label" val="pc_inc_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1630,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1160,1450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Y"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(900,1600)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(570,1140)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(420,1280)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_trig_pc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1940,820)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(1210,780)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Y"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1150,830)" name="Demultiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(2220,1410)" name="Multiplexer">
+      <a name="facing" val="west"/>
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(2300,1160)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="2"/>
+      <a name="label" val="status"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1710,1250)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(420,1330)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_trig_ext"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(590,1200)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="2" loc="(1980,800)" name="Decoder">
+      <a name="selloc" val="tr"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(910,450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="rs0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(890,1720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="startup"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2060,630)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(800,1290)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1390,990)" name="NOT Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(2210,610)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="word"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(770,1410)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(570,1250)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x4"/>
+    </comp>
+    <comp lib="0" loc="(2690,930)" name="Tunnel">
+      <a name="label" val="imm_extend_negative"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2140,680)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="address_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1430,740)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="sp_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1920,1100)" name="Bit Extender">
+      <a name="in_width" val="3"/>
+      <a name="out_width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(1120,1590)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="br_rel_flags_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(2180,750)" name="bus_control">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(2690,970)" name="Tunnel">
+      <a name="label" val="mem"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1740,1080)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="imm6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1190,1190)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="br_rel_flags_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(280,1540)" name="Constant"/>
+    <comp lib="0" loc="(530,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="r2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1410,500)" name="AND Gate">
+      <a name="facing" val="west"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(1840,1220)" name="Priority Encoder"/>
+    <comp lib="0" loc="(1850,490)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="label" val="address_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1080,730)" name="Tunnel">
+      <a name="label" val="imm_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1530,720)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="label" val="pc_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1350,520)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(450,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(780,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(2360,1670)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(2110,760)" name="Controlled Buffer">
+      <a name="facing" val="west"/>
+      <a name="width" val="16"/>
+      <a name="control" val="left"/>
+    </comp>
+    <comp lib="1" loc="(1640,920)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2190,1380)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3_ind"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1420,430)" name="Tunnel">
+      <a name="label" val="pc_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(1260,1210)" name="branch_logic">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="1" loc="(840,1470)" name="OR Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1470,530)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="pc_inc_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(1790,673)" name="Text">
+      <a name="text" val="PS"/>
+      <a name="font" val="SansSerif bold 20"/>
+    </comp>
+    <comp lib="0" loc="(420,1300)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_trig_invalid_inst"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1250,960)" name="Tunnel">
+      <a name="label" val="imm6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(570,1490)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="exc_internal_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(350,1490)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(90,1770)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="CUT"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2160,810)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="inc_address"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1160,490)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="16"/>
+    </comp>
+    <comp lib="0" loc="(2010,1110)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+    </comp>
+    <comp lib="3" loc="(2180,870)" name="Comparator">
+      <a name="width" val="28"/>
+    </comp>
+    <comp lib="0" loc="(1740,1100)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="imm9"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2460,1560)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="arith_carry"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1900,1450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1200,500)" name="Tunnel">
+      <a name="label" val="sp_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2210,1450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="rd"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(660,1250)" name="Register">
+      <a name="width" val="3"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(2690,1230)" name="Tunnel">
+      <a name="label" val="sign_extend"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(360,1560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="2"/>
+      <a name="label" val="status"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="4" loc="(2230,1060)" name="ROM">
       <a name="addrWidth" val="10"/>
@@ -3475,432 +3557,274 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
 127*0 c084088
 </a>
     </comp>
-    <comp lib="0" loc="(2210,610)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="word"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1250,960)" name="Tunnel">
-      <a name="label" val="imm6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1360,1630)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1140,1400)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1280,1320)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="width" val="9"/>
-      <a name="label" val="imm9_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(600,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="6" loc="(1282,702)" name="Text">
-      <a name="text" val="2023"/>
-      <a name="font" val="SansSerif bolditalic 16"/>
-    </comp>
-    <comp lib="0" loc="(220,640)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="r3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(590,1200)" name="OR Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(1370,1110)" name="AND Gate">
+    <comp lib="1" loc="(800,1220)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(280,1540)" name="Constant"/>
-    <comp lib="0" loc="(1890,840)" name="Tunnel">
+    <comp lib="0" loc="(260,990)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="0op"/>
+      <a name="width" val="3"/>
+      <a name="label" val="rd"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(450,1220)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(1430,970)" name="AND Gate">
+    <comp lib="1" loc="(1390,560)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1880,1710)" name="Constant">
-      <a name="width" val="4"/>
-      <a name="value" val="0x2"/>
-    </comp>
-    <comp lib="0" loc="(1710,1310)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="br_abs_nop"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(720,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(660,1150)" name="Tunnel">
-      <a name="label" val="int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="4" loc="(750,1310)" name="S-R Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(1190,1190)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="br_rel_flags_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1130,1630)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="op_type_d2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1580,1700)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="imm6_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(670,1400)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="6"/>
-      <a name="label" val="int_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(120,1530)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="irq"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1810,810)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="0"/>
-    </comp>
-    <comp lib="0" loc="(620,1490)" name="Bit Extender">
-      <a name="in_width" val="3"/>
-    </comp>
-    <comp lib="0" loc="(1370,1570)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="br_abs_flags_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2240,900)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(1790,620)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="labelfont" val="SansSerif plain 16"/>
-    </comp>
-    <comp lib="0" loc="(1350,520)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2140,680)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="address_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(430,1460)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2010,1060)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="2" loc="(2010,1590)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1520,740)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="pc_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(340,1810)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="fetch"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(890,1460)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(2690,1070)" name="Tunnel">
-      <a name="label" val="ps_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(810,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2230,930)" name="Tunnel">
-      <a name="label" val="exc_trig_sp"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2140,600)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1790,540)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="int_en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1650,900)" name="Decoder">
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(1140,1590)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(2270,1480)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="rs0_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1670,810)" name="Tunnel">
-      <a name="label" val="int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(450,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2190,1520)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="imm6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2420,1570)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(420,1300)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_trig_invalid_inst"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,670)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R4"/>
-    </comp>
-    <comp lib="0" loc="(1010,1500)" name="Constant">
-      <a name="width" val="16"/>
-      <a name="value" val="0x8004"/>
-    </comp>
-    <comp lib="0" loc="(1350,1440)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(570,1250)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x4"/>
-    </comp>
-    <comp lib="0" loc="(1260,920)" name="Tunnel">
-      <a name="label" val="mem2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1140,1430)" name="Splitter">
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1740,1020)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="1op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(750,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1700,890)" name="Tunnel">
-      <a name="label" val="ei"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1260,1000)" name="Tunnel">
-      <a name="label" val="mem3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1350,550)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="jsr"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2210,550)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="rd/wr'"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="4" loc="(590,790)" name="Register">
       <a name="width" val="16"/>
       <a name="trigger" val="falling"/>
     </comp>
-    <comp lib="0" loc="(620,1620)" name="Bit Extender">
+    <comp lib="0" loc="(1710,1230)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3_ind"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1370,1200)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(2180,610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1740,1060)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="mem2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1260,880)" name="Tunnel">
+      <a name="label" val="2op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(480,1050)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="1" loc="(1060,740)" name="Controlled Buffer">
+      <a name="facing" val="south"/>
+      <a name="width" val="16"/>
+      <a name="control" val="left"/>
+    </comp>
+    <comp lib="0" loc="(2300,1200)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="latch_int"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1710,1170)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_abs"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1110)" name="Tunnel">
+      <a name="label" val="ps_latch_word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(620,1490)" name="Bit Extender">
       <a name="in_width" val="3"/>
     </comp>
-    <comp lib="0" loc="(1830,670)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2120,770)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="read"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1810,780)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-    </comp>
-    <comp lib="0" loc="(2240,720)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
+    <comp lib="2" loc="(720,1520)" name="Multiplexer">
       <a name="width" val="16"/>
-      <a name="label" val="data_out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="2" loc="(2220,1490)" name="Multiplexer">
-      <a name="facing" val="west"/>
-      <a name="width" val="3"/>
-      <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1820,630)" name="Tunnel">
-      <a name="width" val="4"/>
-      <a name="label" val="ps_flags"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1580,420)" name="Tunnel">
+    <comp lib="0" loc="(2350,1620)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="arith_carry"/>
+      <a name="label" val="alu3_ind"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="5" loc="(1880,540)" name="LED">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(810,1220)" name="Tunnel">
+      <a name="label" val="critical_fault"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(270,1500)" name="OR Gate">
+    <comp lib="0" loc="(2530,1780)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="alu_func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(700,1810)" name="AND Gate">
       <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(120,1380)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="clock"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(1160,800)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="label" val="X"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="6" loc="(446,1572)" name="Text">
-      <a name="text" val="2 - halted"/>
-    </comp>
-    <comp lib="0" loc="(1530,1110)" name="Tunnel">
-      <a name="label" val="br_rel_nop"/>
+    <comp lib="0" loc="(2690,1210)" name="Tunnel">
+      <a name="label" val="read"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1990,1490)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="0" loc="(2350,1560)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(380,1690)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(2100,620)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1220,430)" name="Tunnel">
-      <a name="label" val="sp_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2160,1640)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="imm"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1690,1190)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1450,510)" name="NOT Gate">
-      <a name="facing" val="west"/>
+    <comp lib="1" loc="(130,1780)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="6" loc="(831,1138)" name="Text">
-      <a name="text" val="3. Mutiple exceptions across several phases"/>
+    <comp lib="2" loc="(1080,960)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="6" loc="(1282,680)" name="Text">
-      <a name="text" val="Designed by Nikolay Repin"/>
-      <a name="font" val="SansSerif bolditalic 16"/>
-    </comp>
-    <comp lib="4" loc="(830,790)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(2690,870)" name="Tunnel">
-      <a name="label" val="fp_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1140,1500)" name="Splitter">
+    <comp lib="0" loc="(1990,1450)" name="Splitter">
+      <a name="facing" val="west"/>
       <a name="fanout" val="3"/>
       <a name="incoming" val="3"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="2" loc="(1150,830)" name="Demultiplexer">
+    <comp lib="6" loc="(1789,595)" name="Text">
+      <a name="text" val="CVZN"/>
+    </comp>
+    <comp lib="2" loc="(670,1510)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(2690,910)" name="Tunnel">
+      <a name="label" val="imm_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(1160,512)" name="Text">
+      <a name="text" val="SP"/>
+      <a name="font" val="SansSerif bold 20"/>
+    </comp>
+    <comp lib="0" loc="(1260,1020)" name="Tunnel">
+      <a name="label" val="alu3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(570,1530)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="exc_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(610,1740)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="int_en"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1170)" name="Tunnel">
+      <a name="label" val="r_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1450,490)" name="Tunnel">
+      <a name="label" val="pc_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2310,1690)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(2210,1410)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="rs1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1200,810)" name="Demultiplexer">
       <a name="selloc" val="tr"/>
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="1" loc="(620,1140)" name="OR Gate">
+    <comp lib="0" loc="(2350,1580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="alu3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1260,940)" name="Tunnel">
+      <a name="label" val="alu2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(180,1580)" name="S-R Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="1" loc="(700,1760)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1260,1000)" name="Tunnel">
+      <a name="label" val="mem3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2230,1370)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1650,440)" name="AND Gate">
       <a name="facing" val="west"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(960,1730)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(950,1840)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1420,460)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="pc_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1680,1590)" name="Bit Extender">
+      <a name="in_width" val="9"/>
+    </comp>
+    <comp lib="1" loc="(1760,1320)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(2410,1720)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(720,1700)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="IAck"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1920,650)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="ps_value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(2070,1690)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1970,500)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="address"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(1620,820)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(1600,570)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+    </comp>
+    <comp lib="2" loc="(940,1470)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(710,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="1" loc="(1590,820)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
     </comp>
     <comp lib="0" loc="(190,1760)" name="Tunnel">
       <a name="facing" val="south"/>
@@ -3908,130 +3832,73 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="phase"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(360,990)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="r_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(510,1030)" name="AND Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2190,550)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="read"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1230,1200)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="4"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(570,1490)" name="Tunnel">
-      <a name="facing" val="east"/>
+    <comp lib="0" loc="(1370,1440)" name="Tunnel">
       <a name="width" val="3"/>
-      <a name="label" val="exc_internal_vec"/>
+      <a name="label" val="shift_count_d"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(940,510)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="select" val="3"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(2410,1800)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="alu_op_d0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1050)" name="Tunnel">
-      <a name="label" val="pc_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1590,600)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="cout"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(530,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="r2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2140,620)" name="NOT Gate">
+    <comp lib="1" loc="(390,1450)" name="NOT Gate">
       <a name="size" val="20"/>
     </comp>
-    <comp lib="0" loc="(670,1250)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="exc_internal_vec"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2210,810)" name="Tunnel">
-      <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(2500,1650)" name="OR Gate">
+    <comp lib="0" loc="(1860,650)" name="Splitter">
       <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="0"/>
     </comp>
-    <comp lib="0" loc="(1120,1590)" name="Tunnel">
+    <comp lib="0" loc="(1690,1190)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="br_rel_flags_d"/>
+      <a name="label" val="shifts"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(210,490)" name="Pin">
-      <a name="output" val="true"/>
+    <comp lib="0" loc="(2160,1640)" name="Tunnel">
       <a name="width" val="16"/>
-      <a name="label" val="PS"/>
+      <a name="label" val="imm"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(2520,1780)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(570,1450)" name="Constant">
-      <a name="width" val="3"/>
-      <a name="value" val="0x7"/>
-    </comp>
-    <comp lib="2" loc="(790,1440)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
+    <comp lib="0" loc="(220,730)" name="Tunnel">
       <a name="width" val="16"/>
-      <a name="enable" val="false"/>
+      <a name="label" val="r6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1390,1080)" name="NOT Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="20"/>
+    <comp lib="0" loc="(2270,1450)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="rd_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(860,1710)" name="Pin">
+    <comp lib="0" loc="(1350,1590)" name="Splitter">
       <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="IAck"/>
-      <a name="labelloc" val="east"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
     </comp>
-    <comp lib="6" loc="(1160,512)" name="Text">
-      <a name="text" val="SP"/>
-      <a name="font" val="SansSerif bold 20"/>
+    <comp lib="4" loc="(430,1690)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
     </comp>
-    <comp lib="0" loc="(2000,810)" name="Tunnel">
-      <a name="label" val="jsr"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="2" loc="(2030,1440)" name="Multiplexer">
+      <a name="width" val="3"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="1" loc="(660,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
+    <comp lib="6" loc="(447,1560)" name="Text">
+      <a name="text" val="1 - waiting"/>
     </comp>
-    <comp lib="5" loc="(1830,540)" name="LED">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1420,430)" name="Tunnel">
-      <a name="label" val="pc_asrt0"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1900,1420)" name="OR Gate">
+    <comp lib="1" loc="(1430,1060)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
@@ -4041,36 +3908,387 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="r0"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp loc="(1160,500)" name="sp_register">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(1830,650)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
     </comp>
-    <comp lib="0" loc="(710,720)" name="Tunnel">
+    <comp lib="0" loc="(650,1690)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="fetch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1030)" name="Tunnel">
+      <a name="label" val="pc_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(410,790)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(570,1430)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="exc_internal_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1740,1120)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="mem3"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2190,1520)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="imm6"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(1552,792)" name="Text">
+      <a name="text" val="int, reset"/>
+    </comp>
+    <comp lib="0" loc="(620,1580)" name="Bit Extender">
+      <a name="in_width" val="6"/>
+    </comp>
+    <comp lib="5" loc="(1790,540)" name="LED">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(1710,1310)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="br_abs_nop"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(1282,680)" name="Text">
+      <a name="text" val="Designed by Nikolay Repin"/>
+      <a name="font" val="SansSerif bolditalic 16"/>
+    </comp>
+    <comp lib="0" loc="(2190,530)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="data"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(690,1340)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="reset_exc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(420,1260)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="exc_trig_sp"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(920,1490)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="startup"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(830,720)" name="Tunnel">
       <a name="facing" val="east"/>
       <a name="width" val="16"/>
-      <a name="label" val="r5"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1860,1410)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1730,1690)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(2110,1660)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="int"/>
+      <a name="label" val="fp"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="4" loc="(650,790)" name="Register">
       <a name="width" val="16"/>
       <a name="trigger" val="falling"/>
     </comp>
-    <comp lib="2" loc="(670,1600)" name="Multiplexer">
+    <comp lib="0" loc="(360,1450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1080,1520)" name="Tunnel">
+      <a name="label" val="double_fault"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1520,740)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="pc_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2370,1710)" name="Constant">
+      <a name="width" val="3"/>
+      <a name="value" val="0x5"/>
+    </comp>
+    <comp lib="0" loc="(670,1250)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="exc_internal_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(130,640)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R3"/>
+    </comp>
+    <comp lib="0" loc="(120,1610)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(230,1110)" name="Tunnel">
+      <a name="width" val="6"/>
+      <a name="label" val="exc_vec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1130,480)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="busD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="6" loc="(501,1190)" name="Text">
+      <a name="text" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2140,600)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,430)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="SP"/>
+    </comp>
+    <comp lib="0" loc="(710,1550)" name="Tunnel">
+      <a name="label" val="exc_trig_ext"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1540,820)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+      <a name="bit0" val="none"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="1"/>
+      <a name="bit3" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2210,1490)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="rs0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(980,1600)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(2050,1730)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+    </comp>
+    <comp lib="4" loc="(180,1500)" name="S-R Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(1980,1720)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="0" loc="(620,1530)" name="Bit Extender">
+      <a name="in_width" val="6"/>
+    </comp>
+    <comp lib="0" loc="(1190,1210)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="br_abs_flags_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1150,1010)" name="Demultiplexer">
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1520,920)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(2390,1090)" name="Splitter">
+      <a name="fanout" val="28"/>
+      <a name="incoming" val="28"/>
+      <a name="appear" val="right"/>
+    </comp>
+    <comp lib="1" loc="(1990,1490)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(1350,550)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="jsr"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1770,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="ps_latch_flags"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(220,550)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="r0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1410,1200)" name="Tunnel">
+      <a name="label" val="br_rel_p"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(630,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1730,1690)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1250,860)" name="Tunnel">
+      <a name="label" val="1op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1210,1170)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="br_abs_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1880,930)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2240,770)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="data_in"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1350,570)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="pc_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1250,980)" name="Tunnel">
+      <a name="label" val="imm9"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(140,1200)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="IRQ"/>
+    </comp>
+    <comp lib="0" loc="(1350,1350)" name="Tunnel">
+      <a name="width" val="6"/>
+      <a name="label" val="imm6_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(380,1510)" name="Tunnel">
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(370,410)" name="Pull Resistor">
+      <a name="facing" val="east"/>
+    </comp>
+    <comp lib="0" loc="(2410,1780)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="alu_op_d1"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(2130,1640)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(2290,890)" name="Tunnel">
+      <a name="label" val="exc_trig_invalid_inst"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(340,1700)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1650,990)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="exc_triggered"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1350,1500)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(140,1240)" name="Pin">
+      <a name="width" val="6"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="int_vec"/>
+    </comp>
+    <comp lib="3" loc="(620,1440)" name="Comparator">
+      <a name="width" val="3"/>
+      <a name="mode" val="unsigned"/>
+    </comp>
+    <comp lib="0" loc="(1790,720)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="clk"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(650,1730)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1200,520)" name="Tunnel">
+      <a name="label" val="sp_dec"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(1160,500)" name="sp_register">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(120,1500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="wait"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1900,1420)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(250,1810)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="2" loc="(790,1440)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
       <a name="width" val="16"/>
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(1390,1170)" name="NOT Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(1010,1500)" name="Constant">
+      <a name="width" val="16"/>
+      <a name="value" val="0x8004"/>
+    </comp>
+    <comp lib="0" loc="(2300,1180)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="startup"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1000,580)" name="Tunnel">
       <a name="facing" val="south"/>
@@ -4078,58 +4296,73 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="bus1"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2300,1160)" name="Tunnel">
+    <comp lib="0" loc="(1860,1430)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="width" val="2"/>
-      <a name="label" val="status"/>
+      <a name="label" val="alu3_ind"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1080,1520)" name="Tunnel">
-      <a name="label" val="double_fault"/>
+    <comp lib="6" loc="(655,1176)" name="Text">
+      <a name="text" val="int, reset, rti"/>
+    </comp>
+    <comp lib="0" loc="(1860,670)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="int_en"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1550,500)" name="Tunnel">
+    <comp lib="1" loc="(2240,900)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(230,1860)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="CUT"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1680,1630)" name="Bit Extender">
+      <a name="in_width" val="9"/>
+      <a name="type" val="one"/>
+    </comp>
+    <comp lib="0" loc="(1740,670)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="alu_func"/>
+      <a name="label" val="ei"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(1730,1200)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="2" loc="(1590,450)" name="Multiplexer">
+      <a name="facing" val="west"/>
+      <a name="selloc" val="tr"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(1600,580)" name="Splitter">
-      <a name="facing" val="south"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-      <a name="bit0" val="none"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="0"/>
-    </comp>
-    <comp lib="0" loc="(700,1320)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(840,1820)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(420,1330)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_trig_ext"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1850,490)" name="Tunnel">
-      <a name="facing" val="south"/>
+    <comp lib="0" loc="(220,460)" name="Tunnel">
       <a name="width" val="16"/>
-      <a name="label" val="address_out"/>
+      <a name="label" val="pc_value"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(2000,1630)" name="Tunnel">
-      <a name="label" val="imm_shift"/>
+    <comp lib="1" loc="(390,840)" name="AND Gate">
+      <a name="facing" val="north"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1320,520)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="pc_latch"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1580,1700)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="6"/>
+      <a name="label" val="imm6_d"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,1250)" name="Tunnel">
+      <a name="label" val="sp_asrt0"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(510,1030)" name="AND Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(190,1070)" name="Tunnel">
+      <a name="label" val="exc_trig_ext"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1370,1590)" name="Tunnel">
@@ -4137,62 +4370,64 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="op_type_d0"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="3" loc="(1960,1610)" name="Shifter">
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(2010,1130)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="3"/>
-      <a name="label" val="phase"/>
+    <comp lib="0" loc="(1700,910)" name="Tunnel">
+      <a name="label" val="di"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(840,1770)" name="OR Gate">
+    <comp lib="0" loc="(210,670)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R4"/>
+    </comp>
+    <comp lib="0" loc="(1920,720)" name="Tunnel">
+      <a name="label" val="ps_asrtD"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1640,470)" name="Tunnel">
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2690,950)" name="Tunnel">
+      <a name="label" val="imm_shift"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(700,1700)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(230,1110)" name="Tunnel">
-      <a name="width" val="6"/>
-      <a name="label" val="exc_vec"/>
+    <comp lib="4" loc="(180,1660)" name="S-R Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(440,1460)" name="Tunnel">
+      <a name="label" val="clk"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp loc="(1360,500)" name="pc_register">
-      <a name="facing" val="north"/>
+    <comp lib="1" loc="(2280,890)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(870,1430)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="latch_int"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="2" loc="(2310,1070)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="28"/>
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(230,1860)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="CUT"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="1" loc="(2220,970)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(620,1580)" name="Bit Extender">
-      <a name="in_width" val="6"/>
-    </comp>
-    <comp lib="0" loc="(2390,1090)" name="Splitter">
-      <a name="fanout" val="28"/>
-      <a name="incoming" val="28"/>
-      <a name="appear" val="right"/>
-    </comp>
-    <comp lib="0" loc="(2300,1200)" name="Tunnel">
+    <comp lib="0" loc="(1530,820)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="latch_int"/>
+      <a name="width" val="4"/>
+      <a name="label" val="op_type_d3"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(90,1770)" name="Tunnel">
+    <comp lib="0" loc="(1260,920)" name="Tunnel">
+      <a name="label" val="mem2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(2190,1360)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="CUT"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1160,490)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="16"/>
-    </comp>
-    <comp lib="0" loc="(1650,990)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="exc_triggered"/>
+      <a name="label" val="1op"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(1590,580)" name="Tunnel">
@@ -4201,201 +4436,36 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="CVZN"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1190,1210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="4"/>
-      <a name="label" val="br_abs_flags_d"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(200,1130)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2160,810)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="inc_address"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2690,1370)" name="Tunnel">
-      <a name="label" val="CUT"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2210,680)" name="Tunnel">
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="3" loc="(1060,1510)" name="Comparator">
-      <a name="width" val="16"/>
-      <a name="mode" val="unsigned"/>
-    </comp>
-    <comp lib="0" loc="(360,1590)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="status"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1740,690)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="di"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(530,1290)" name="Priority Encoder"/>
-    <comp lib="0" loc="(1200,500)" name="Tunnel">
-      <a name="label" val="sp_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1260,1020)" name="Tunnel">
-      <a name="label" val="alu3"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(390,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1260,900)" name="Tunnel">
-      <a name="label" val="alu3_ind"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(940,660)" name="Multiplexer">
-      <a name="select" val="3"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="1" loc="(690,840)" name="AND Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(1390,560)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1330,480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="busD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(780,1050)" name="Controlled Buffer">
-      <a name="facing" val="south"/>
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(140,1070)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="EXC"/>
-    </comp>
-    <comp lib="0" loc="(770,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="r6"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(530,1150)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(270,1770)" name="NOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="5" loc="(1790,540)" name="LED">
-      <a name="facing" val="south"/>
-    </comp>
-    <comp lib="0" loc="(1690,1210)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="alu2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
     <comp lib="1" loc="(570,840)" name="AND Gate">
       <a name="facing" val="north"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(2190,510)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="mem"/>
+    <comp lib="2" loc="(270,980)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(1570,960)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="0" loc="(130,700)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="R5"/>
+    </comp>
+    <comp lib="0" loc="(2230,930)" name="Tunnel">
+      <a name="label" val="exc_trig_sp"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(2420,1610)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(2040,1440)" name="Tunnel">
+    <comp lib="0" loc="(910,720)" name="Tunnel">
+      <a name="facing" val="east"/>
       <a name="width" val="3"/>
-      <a name="label" val="alu_op_type"/>
+      <a name="label" val="rs1"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(130,580)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R1"/>
-    </comp>
-    <comp lib="1" loc="(1530,750)" name="Controlled Buffer">
+    <comp lib="1" loc="(660,1050)" name="Controlled Buffer">
       <a name="facing" val="south"/>
       <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(2210,900)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="exc_latch"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2140,700)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="sign_extend"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(770,1410)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="exc_triggered"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(920,1490)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="startup"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1920,720)" name="Tunnel">
-      <a name="label" val="ps_asrtD"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2190,1360)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="1op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(2050,1060)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="10"/>
-      <a name="incoming" val="10"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1880,540)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,550)" name="Pin">
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="R0"/>
-    </comp>
-    <comp lib="0" loc="(1150,520)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="clk"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(220,580)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="r1"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(650,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="r4"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
   </circuit>
   <circuit name="sp_register">
@@ -4447,43 +4517,13 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(540,540)" to="(550,540)"/>
     <wire from="(570,730)" to="(580,730)"/>
     <wire from="(530,740)" to="(540,740)"/>
-    <comp lib="0" loc="(550,570)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="clk"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(570,730)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(500,710)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="2" loc="(490,500)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(530,740)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="up"/>
-      <a name="label" val="en"/>
-    </comp>
-    <comp lib="0" loc="(650,520)" name="Tunnel">
+    <comp lib="0" loc="(750,520)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="label" val="+2"/>
+      <a name="label" val="-2"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="4" loc="(550,500)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(460,700)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="+2"/>
+    <comp lib="0" loc="(580,730)" name="Tunnel">
+      <a name="label" val="en"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(520,700)" name="Tunnel">
@@ -4491,28 +4531,18 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="count"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(290,740)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="+2"/>
-    </comp>
     <comp lib="0" loc="(300,770)" name="Tunnel">
       <a name="label" val="-2"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(290,770)" name="Pin">
+    <comp lib="0" loc="(330,490)" name="Pin">
+      <a name="width" val="16"/>
       <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="-2"/>
+      <a name="label" val="In"/>
     </comp>
-    <comp lib="0" loc="(300,740)" name="Tunnel">
-      <a name="label" val="+2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(470,520)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="count"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="1" loc="(570,730)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(600,600)" name="Pin">
       <a name="facing" val="north"/>
@@ -4521,23 +4551,6 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="Mon"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(800,490)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="Out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(460,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="-2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(750,520)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="-2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
     <comp lib="0" loc="(550,540)" name="Pin">
       <a name="facing" val="west"/>
       <a name="tristate" val="false"/>
@@ -4545,26 +4558,83 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="clr"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="2" loc="(490,500)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(550,500)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
     <comp lib="0" loc="(510,540)" name="Tunnel">
       <a name="facing" val="north"/>
       <a name="label" val="en"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(580,730)" name="Tunnel">
-      <a name="label" val="en"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(330,490)" name="Pin">
-      <a name="width" val="16"/>
+    <comp lib="0" loc="(290,740)" name="Pin">
       <a name="tristate" val="false"/>
-      <a name="label" val="In"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="+2"/>
     </comp>
     <comp lib="2" loc="(770,490)" name="Multiplexer">
       <a name="width" val="16"/>
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
     </comp>
+    <comp lib="1" loc="(500,710)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(460,700)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="+2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,770)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="-2"/>
+    </comp>
+    <comp lib="0" loc="(800,490)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="Out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
     <comp loc="(650,500)" name="incdec2"/>
+    <comp lib="0" loc="(650,520)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="+2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(470,520)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="count"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(300,740)" name="Tunnel">
+      <a name="label" val="+2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(550,570)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="clk"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(530,740)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="up"/>
+      <a name="label" val="en"/>
+    </comp>
+    <comp lib="0" loc="(460,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="-2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
   </circuit>
   <circuit name="pc_register">
     <a name="circuit" val="pc_register"/>
@@ -4615,19 +4685,17 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(570,730)" to="(580,730)"/>
     <wire from="(530,740)" to="(540,740)"/>
     <wire from="(510,720)" to="(520,720)"/>
-    <comp lib="4" loc="(550,500)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
+    <comp lib="0" loc="(760,520)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="asrt_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(290,830)" name="Pin">
+    <comp lib="0" loc="(550,540)" name="Pin">
+      <a name="facing" val="west"/>
       <a name="tristate" val="false"/>
       <a name="pull" val="down"/>
-      <a name="label" val="inverse_inc"/>
-    </comp>
-    <comp lib="0" loc="(330,490)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="In"/>
+      <a name="label" val="clr"/>
+      <a name="labelloc" val="east"/>
     </comp>
     <comp lib="0" loc="(300,770)" name="Tunnel">
       <a name="label" val="+2"/>
@@ -4638,35 +4706,45 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="pull" val="down"/>
       <a name="label" val="asrt_inc"/>
     </comp>
-    <comp lib="0" loc="(550,540)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="clr"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(470,520)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="count"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(660,550)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="inverse_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(530,740)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="up"/>
-      <a name="label" val="en"/>
-    </comp>
-    <comp lib="0" loc="(760,520)" name="Tunnel">
-      <a name="facing" val="north"/>
+    <comp lib="0" loc="(300,800)" name="Tunnel">
       <a name="label" val="asrt_inc"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(580,730)" name="Tunnel">
-      <a name="label" val="en"/>
+    <comp lib="0" loc="(810,490)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="Out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(610,590)" name="Pin">
+      <a name="facing" val="north"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="Mon"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(290,770)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="+2"/>
+    </comp>
+    <comp lib="1" loc="(570,730)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(300,830)" name="Tunnel">
+      <a name="label" val="inverse_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(330,490)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="In"/>
+    </comp>
+    <comp lib="0" loc="(520,700)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="count"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="1" loc="(660,520)" name="NOT Gate">
@@ -4678,46 +4756,6 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="en"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(510,720)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="+2"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(520,700)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="count"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(490,500)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(300,800)" name="Tunnel">
-      <a name="label" val="asrt_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(300,830)" name="Tunnel">
-      <a name="label" val="inverse_inc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(570,730)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp loc="(660,500)" name="incdec2"/>
-    <comp lib="0" loc="(290,770)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="+2"/>
-    </comp>
-    <comp lib="0" loc="(810,490)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="Out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="0" loc="(550,570)" name="Pin">
       <a name="facing" val="west"/>
       <a name="tristate" val="false"/>
@@ -4725,17 +4763,49 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="clk"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(610,590)" name="Pin">
+    <comp lib="0" loc="(290,830)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="inverse_inc"/>
+    </comp>
+    <comp lib="0" loc="(660,550)" name="Tunnel">
       <a name="facing" val="north"/>
-      <a name="output" val="true"/>
+      <a name="label" val="inverse_inc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(550,500)" name="Register">
       <a name="width" val="16"/>
-      <a name="label" val="Mon"/>
-      <a name="labelloc" val="east"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(580,730)" name="Tunnel">
+      <a name="label" val="en"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(490,500)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(530,740)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="up"/>
+      <a name="label" val="en"/>
+    </comp>
+    <comp loc="(660,500)" name="incdec2"/>
+    <comp lib="0" loc="(510,720)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="+2"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="2" loc="(780,490)" name="Multiplexer">
       <a name="width" val="16"/>
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(470,520)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="count"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
   </circuit>
   <circuit name="ps_register">
@@ -4808,32 +4878,6 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(370,540)" to="(370,590)"/>
     <wire from="(300,540)" to="(370,540)"/>
     <wire from="(490,410)" to="(490,530)"/>
-    <comp lib="0" loc="(370,590)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="ei"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(480,530)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(430,550)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(350,590)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="di"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(580,400)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="0" loc="(640,320)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -4841,6 +4885,74 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="tristate" val="false"/>
       <a name="label" val="out_flags"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(500,350)" name="Tunnel">
+      <a name="label" val="ei"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(300,560)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="di"/>
+    </comp>
+    <comp lib="0" loc="(350,590)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="di"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(510,50)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="flags"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(530,400)" name="Register">
+      <a name="width" val="16"/>
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(360,320)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="word"/>
+    </comp>
+    <comp lib="0" loc="(500,270)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="15"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+      <a name="bit15" val="none"/>
+    </comp>
+    <comp lib="0" loc="(300,500)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="latch_word"/>
+    </comp>
+    <comp lib="0" loc="(460,280)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(300,520)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="latch_flags"/>
+    </comp>
+    <comp lib="1" loc="(430,510)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(370,590)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="ei"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(400,240)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="set_int_flag"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="2" loc="(380,210)" name="Multiplexer">
       <a name="facing" val="west"/>
@@ -4852,61 +4964,26 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="pull" val="down"/>
       <a name="label" val="ei"/>
     </comp>
-    <comp lib="0" loc="(500,50)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(450,560)" name="Tunnel">
-      <a name="label" val="set_int_flag"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(360,320)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="word"/>
-    </comp>
-    <comp lib="0" loc="(500,350)" name="Tunnel">
-      <a name="label" val="ei"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(300,450)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="clk"/>
-    </comp>
     <comp lib="0" loc="(620,320)" name="Bit Extender">
       <a name="in_width" val="16"/>
       <a name="out_width" val="4"/>
     </comp>
-    <comp lib="4" loc="(530,400)" name="Register">
-      <a name="width" val="16"/>
-      <a name="trigger" val="falling"/>
+    <comp lib="1" loc="(480,530)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
-    <comp lib="0" loc="(400,240)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="set_int_flag"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(460,280)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(510,50)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="width" val="4"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="flags"/>
-      <a name="labelloc" val="east"/>
+    <comp lib="1" loc="(430,550)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(460,110)" name="Splitter">
       <a name="fanout" val="16"/>
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(450,560)" name="Tunnel">
+      <a name="label" val="set_int_flag"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(500,130)" name="Splitter">
       <a name="facing" val="west"/>
@@ -4930,35 +5007,28 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="bit14" val="10"/>
       <a name="bit15" val="11"/>
     </comp>
-    <comp lib="0" loc="(300,560)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="di"/>
-    </comp>
-    <comp lib="1" loc="(430,510)" name="OR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(300,520)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="latch_flags"/>
-    </comp>
-    <comp lib="0" loc="(500,270)" name="Splitter">
+    <comp lib="0" loc="(580,400)" name="Pin">
       <a name="facing" val="west"/>
-      <a name="fanout" val="15"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-      <a name="bit15" val="none"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(300,450)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="clk"/>
     </comp>
     <comp lib="2" loc="(460,400)" name="Multiplexer">
       <a name="width" val="16"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(300,500)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="latch_word"/>
+    <comp lib="0" loc="(500,50)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
     </comp>
   </circuit>
   <circuit name="incdec2">
@@ -4986,25 +5056,6 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="width" val="16"/>
       <a name="value" val="0xfffe"/>
     </comp>
-    <comp lib="2" loc="(480,420)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="3" loc="(580,400)" name="Adder">
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(360,390)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="in"/>
-    </comp>
-    <comp lib="0" loc="(670,400)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
     <comp lib="0" loc="(460,460)" name="Pin">
       <a name="facing" val="north"/>
       <a name="tristate" val="false"/>
@@ -5015,6 +5066,25 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <comp lib="0" loc="(440,430)" name="Constant">
       <a name="width" val="16"/>
       <a name="value" val="0x2"/>
+    </comp>
+    <comp lib="2" loc="(480,420)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(670,400)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(360,390)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="in"/>
+    </comp>
+    <comp lib="3" loc="(580,400)" name="Adder">
+      <a name="width" val="16"/>
     </comp>
   </circuit>
   <circuit name="bus_control">
@@ -5112,121 +5182,20 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(580,470)" to="(590,470)"/>
     <wire from="(600,490)" to="(610,490)"/>
     <wire from="(310,730)" to="(380,730)"/>
-    <comp loc="(590,670)" name="make_byte"/>
-    <comp lib="0" loc="(710,700)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="to_bus"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(200,120)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="sign_extend"/>
-    </comp>
-    <comp lib="4" loc="(540,780)" name="Register">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="4" loc="(670,120)" name="D Flip-Flop">
-      <a name="trigger" val="falling"/>
-    </comp>
-    <comp lib="0" loc="(200,150)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="odd_address"/>
-    </comp>
-    <comp lib="0" loc="(560,860)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
+    <comp loc="(590,690)" name="2s_compliment"/>
     <comp lib="0" loc="(770,240)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="label" val="clk_inhibit"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="1" loc="(470,830)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(630,650)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="sign_extend"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(580,410)" name="make_byte"/>
-    <comp lib="0" loc="(200,220)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="label" val="clk_no_inhibit"/>
-    </comp>
     <comp lib="0" loc="(720,150)" name="Tunnel">
       <a name="label" val="phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(330,430)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="from_bus"/>
-    </comp>
-    <comp lib="0" loc="(760,260)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(700,700)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(470,780)" name="Bit Extender">
-      <a name="in_width" val="16"/>
-      <a name="out_width" val="8"/>
-    </comp>
-    <comp lib="0" loc="(420,840)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(200,180)" name="Pin">
       <a name="tristate" val="false"/>
       <a name="label" val="word"/>
-    </comp>
-    <comp lib="0" loc="(680,670)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,220)" name="Tunnel">
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(590,690)" name="2s_compliment"/>
-    <comp lib="0" loc="(620,180)" name="Tunnel">
-      <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(640,750)" name="Tunnel">
-      <a name="label" val="phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(680,440)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="data_out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(620,120)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_no_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(310,730)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="data_in"/>
     </comp>
     <comp lib="0" loc="(560,170)" name="Tunnel">
       <a name="facing" val="east"/>
@@ -5237,55 +5206,38 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="word"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp loc="(560,470)" name="bytes_swap"/>
-    <comp lib="0" loc="(770,120)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="inc_address"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(600,180)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(210,150)" name="Tunnel">
-      <a name="label" val="odd"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(760,240)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="clk_inhibit"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(560,780)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(650,410)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="word"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
     <comp lib="2" loc="(650,680)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="16"/>
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="2" loc="(620,460)" name="Multiplexer">
+    <comp lib="0" loc="(640,750)" name="Tunnel">
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(650,720)" name="Multiplexer">
       <a name="width" val="16"/>
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(420,820)" name="Tunnel">
+    <comp lib="0" loc="(330,430)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="from_bus"/>
+    </comp>
+    <comp lib="0" loc="(560,190)" name="Tunnel">
       <a name="facing" val="east"/>
-      <a name="label" val="clk_inhibit"/>
+      <a name="label" val="word"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(610,490)" name="Tunnel">
-      <a name="label" val="phase"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="0" loc="(200,220)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="clk_no_inhibit"/>
+    </comp>
+    <comp lib="1" loc="(600,180)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
     </comp>
     <comp lib="0" loc="(600,820)" name="Splitter">
       <a name="facing" val="west"/>
@@ -5293,16 +5245,101 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="2" loc="(650,720)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="disabled" val="0"/>
-      <a name="enable" val="false"/>
+    <comp lib="0" loc="(760,260)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(670,440)" name="Multiplexer">
+    <comp lib="0" loc="(200,150)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="odd_address"/>
+    </comp>
+    <comp lib="0" loc="(620,120)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="4" loc="(540,780)" name="Register">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="1" loc="(470,830)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(700,700)" name="Multiplexer">
       <a name="selloc" val="tr"/>
       <a name="width" val="16"/>
       <a name="disabled" val="0"/>
       <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(310,730)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="data_in"/>
+    </comp>
+    <comp lib="0" loc="(760,240)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(680,670)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="word"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(200,120)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="sign_extend"/>
+    </comp>
+    <comp lib="4" loc="(670,120)" name="D Flip-Flop">
+      <a name="trigger" val="falling"/>
+    </comp>
+    <comp lib="0" loc="(560,860)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(710,700)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="to_bus"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(630,650)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="sign_extend"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(620,460)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(210,120)" name="Tunnel">
+      <a name="label" val="sign_extend"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(610,490)" name="Tunnel">
+      <a name="label" val="phase"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(420,840)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(770,120)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="inc_address"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(560,780)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(770,260)" name="Pin">
       <a name="facing" val="west"/>
@@ -5310,14 +5347,47 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="phase"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(560,190)" name="Tunnel">
+    <comp lib="0" loc="(210,220)" name="Tunnel">
+      <a name="label" val="clk_no_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(580,410)" name="make_byte"/>
+    <comp loc="(590,670)" name="make_byte"/>
+    <comp lib="0" loc="(680,440)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="data_out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(620,180)" name="Tunnel">
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,150)" name="Tunnel">
+      <a name="label" val="odd"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(420,820)" name="Tunnel">
       <a name="facing" val="east"/>
+      <a name="label" val="clk_inhibit"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(470,780)" name="Bit Extender">
+      <a name="in_width" val="16"/>
+      <a name="out_width" val="8"/>
+    </comp>
+    <comp lib="0" loc="(650,410)" name="Tunnel">
+      <a name="facing" val="south"/>
       <a name="label" val="word"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(210,120)" name="Tunnel">
-      <a name="label" val="sign_extend"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp loc="(560,470)" name="bytes_swap"/>
+    <comp lib="2" loc="(670,440)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="16"/>
+      <a name="disabled" val="0"/>
+      <a name="enable" val="false"/>
     </comp>
   </circuit>
   <circuit name="alu">
@@ -5593,349 +5663,20 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(1060,720)" to="(1080,720)"/>
     <wire from="(560,710)" to="(570,710)"/>
     <wire from="(620,1010)" to="(630,1010)"/>
-    <comp lib="1" loc="(570,510)" name="NOT Gate">
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(200,280)" name="Splitter">
-      <a name="fanout" val="3"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="1" loc="(890,90)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(490,130)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="B"/>
-    </comp>
-    <comp lib="0" loc="(290,610)" name="Tunnel">
-      <a name="label" val="scl"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(600,600)" name="Multiplexer">
-      <a name="selloc" val="tr"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(200,170)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(670,670)" name="Tunnel">
-      <a name="label" val="adder_c"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1050,690)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="adder_c"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1010,740)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="adder_c"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,80)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="C"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp loc="(570,840)" name="2s_compliment"/>
-    <comp lib="0" loc="(690,820)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="unary_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1030,300)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1070,680)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(290,860)" name="Tunnel">
-      <a name="label" val="rcr"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(610,460)" name="XOR Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(190,280)" name="Pin">
-      <a name="width" val="3"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="op_type"/>
-    </comp>
-    <comp lib="0" loc="(290,430)" name="Tunnel">
-      <a name="label" val="bic"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(740,430)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1010,920)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="adder_v"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(630,1010)" name="Tunnel">
-      <a name="label" val="shifter_c"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
     <comp lib="0" loc="(980,90)" name="Tunnel">
       <a name="label" val="sub"/>
       <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(600,970)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(660,860)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="none"/>
-    </comp>
-    <comp lib="0" loc="(1070,930)" name="Constant">
-      <a name="facing" val="north"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(190,140)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="Cin"/>
-    </comp>
-    <comp lib="1" loc="(850,130)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="0" loc="(720,470)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(960,150)" name="OR Gate">
-      <a name="facing" val="south"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="2" loc="(1120,910)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(240,300)" name="Tunnel">
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,820)" name="Tunnel">
-      <a name="label" val="ror"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1070,860)" name="Constant">
-      <a name="facing" val="south"/>
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(1310,100)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="V"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(720,470)" name="Splitter">
-      <a name="facing" val="north"/>
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="3"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="0"/>
-      <a name="bit2" val="none"/>
-    </comp>
-    <comp lib="0" loc="(200,140)" name="Tunnel">
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(170,680)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,470)" name="Tunnel">
-      <a name="label" val="adc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,120)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="Z"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,590)" name="Tunnel">
-      <a name="label" val="sxt"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(600,710)" name="Tunnel">
-      <a name="label" val="sbc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(210,1010)" name="Pin">
-      <a name="width" val="3"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="shift_count"/>
-    </comp>
-    <comp lib="1" loc="(2850,390)" name="NOT Gate"/>
-    <comp lib="0" loc="(1050,870)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="adder_v"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1090,360)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="2op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1130,730)" name="Tunnel">
-      <a name="label" val="C"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(580,810)" name="NOT Gate">
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(490,70)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="A"/>
     </comp>
     <comp lib="0" loc="(290,450)" name="Tunnel">
       <a name="label" val="add"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(290,840)" name="Tunnel">
-      <a name="label" val="rcl"/>
+    <comp lib="0" loc="(290,510)" name="Tunnel">
+      <a name="label" val="sbc"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="2" loc="(190,470)" name="Decoder">
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp loc="(1300,610)" name="zero16"/>
-    <comp lib="0" loc="(240,260)" name="Tunnel">
-      <a name="label" val="3op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(810,100)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="adc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(670,650)" name="Tunnel">
-      <a name="label" val="adder_v"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1050,570)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="unary_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(640,620)" name="adder16">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1250,320)" name="Pull Resistor">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1090,390)" name="Tunnel">
-      <a name="facing" val="east"/>
+    <comp lib="0" loc="(240,300)" name="Tunnel">
       <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(640,590)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="adder_carry"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(600,780)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="adder_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,570)" name="Tunnel">
-      <a name="label" val="not"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1220,320)" name="Priority Encoder">
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(1070,760)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="shifter_c"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,120)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="Z"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(1050,590)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="shifter_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,80)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="C"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,370)" name="Tunnel">
-      <a name="label" val="and"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(980,70)" name="Tunnel">
-      <a name="label" val="neg"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(1120,730)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(290,800)" name="Tunnel">
-      <a name="label" val="rol"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1090,290)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="1" loc="(610,500)" name="AND Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(580,670)" name="OR Gate">
-      <a name="facing" val="north"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1090,330)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="3op"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(190,170)" name="Pin">
@@ -5944,28 +5685,176 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="pull" val="down"/>
       <a name="label" val="func"/>
     </comp>
+    <comp lib="0" loc="(810,40)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="sbc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1280,320)" name="Tunnel">
+      <a name="width" val="2"/>
+      <a name="label" val="encoded_type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(940,70)" name="OR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(190,650)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(600,780)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="adder_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1120,910)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(570,510)" name="NOT Gate">
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1090,270)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="3op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1310,100)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="V"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(980,70)" name="Tunnel">
+      <a name="label" val="neg"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(670,670)" name="Tunnel">
+      <a name="label" val="adder_c"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(600,710)" name="Tunnel">
+      <a name="label" val="sbc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1310,120)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="Z"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1010,920)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="adder_v"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(630,990)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="shifter_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1130,730)" name="Tunnel">
+      <a name="label" val="C"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1050,870)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="adder_v"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp loc="(570,840)" name="2s_compliment"/>
+    <comp lib="0" loc="(1090,390)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,430)" name="Tunnel">
+      <a name="label" val="bic"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(810,100)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="adc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1120,560)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
     <comp lib="0" loc="(500,70)" name="Tunnel">
       <a name="width" val="16"/>
       <a name="label" val="A"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(1330,640)" name="Tunnel">
-      <a name="label" val="N"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
+    <comp lib="2" loc="(1050,730)" name="Multiplexer">
+      <a name="enable" val="false"/>
     </comp>
-    <comp lib="0" loc="(290,780)" name="Tunnel">
-      <a name="label" val="shra"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1050,530)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="logic_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1130,320)" name="AND Gate">
+    <comp lib="1" loc="(580,670)" name="OR Gate">
+      <a name="facing" val="north"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(190,840)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(670,650)" name="Tunnel">
+      <a name="label" val="adder_v"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1050,690)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="adder_c"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1070,860)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="2" loc="(600,640)" name="Multiplexer">
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1030,750)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="neg"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(560,710)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="sub"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1070,930)" name="Constant">
+      <a name="facing" val="north"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(170,500)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1030,930)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="neg"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1250,320)" name="Pull Resistor">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(1110,940)" name="Tunnel">
+      <a name="width" val="2"/>
+      <a name="label" val="encoded_type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1130,280)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(580,810)" name="NOT Gate">
+      <a name="width" val="16"/>
     </comp>
     <comp lib="0" loc="(1030,300)" name="Splitter">
       <a name="fanout" val="1"/>
@@ -5975,171 +5864,12 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="bit1" val="none"/>
       <a name="bit2" val="0"/>
     </comp>
-    <comp lib="0" loc="(290,410)" name="Tunnel">
-      <a name="label" val="xor"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1110,940)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="encoded_type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1010,720)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="2" loc="(1050,910)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1280,320)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="encoded_type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(890,50)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1310,100)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="V"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(1220,1710)" name="NOT Gate"/>
-    <comp lib="0" loc="(470,450)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="A"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
     <comp lib="0" loc="(290,490)" name="Tunnel">
       <a name="label" val="sub"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(290,390)" name="Tunnel">
-      <a name="label" val="or"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(560,710)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="sub"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(470,470)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="B"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,510)" name="Tunnel">
-      <a name="label" val="sbc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(170,850)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="shifts"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(190,840)" name="Decoder">
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(170,500)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1310,140)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="N"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp loc="(570,870)" name="make_byte"/>
-    <comp lib="0" loc="(630,990)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="shifter_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(170,480)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="3op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(600,1030)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(600,640)" name="Multiplexer">
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(750,430)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="logic_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,760)" name="Tunnel">
-      <a name="label" val="shr"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(810,70)" name="Tunnel">
-      <a name="facing" val="east"/>
+    <comp lib="0" loc="(200,140)" name="Tunnel">
       <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(810,40)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="sbc"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(580,570)" name="Tunnel">
-      <a name="facing" val="south"/>
-      <a name="label" val="neg"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(1130,280)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1030,750)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="neg"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1210,520)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="16"/>
-    </comp>
-    <comp lib="2" loc="(1120,560)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="2" loc="(1050,730)" name="Multiplexer">
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(1050,550)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="width" val="16"/>
-      <a name="label" val="adder_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(660,860)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="width" val="3"/>
-      <a name="label" val="func"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1010,900)" name="Constant">
-      <a name="value" val="0x0"/>
-    </comp>
-    <comp lib="0" loc="(1110,590)" name="Tunnel">
-      <a name="width" val="2"/>
-      <a name="label" val="encoded_type"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="0" loc="(170,870)" name="Tunnel">
@@ -6148,84 +5878,9 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="func"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(170,660)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="2op"/>
+    <comp lib="0" loc="(1130,910)" name="Tunnel">
+      <a name="label" val="V"/>
       <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(670,610)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="adder_out"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(560,610)" name="NOT Gate">
-      <a name="width" val="16"/>
-    </comp>
-    <comp lib="0" loc="(500,130)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="B"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,550)" name="Tunnel">
-      <a name="label" val="neg"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(290,740)" name="Tunnel">
-      <a name="label" val="shl"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="1" loc="(610,420)" name="OR Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(960,160)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="adder_carry"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1030,930)" name="Tunnel">
-      <a name="facing" val="north"/>
-      <a name="label" val="neg"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp loc="(600,1000)" name="barrel_shifter">
-      <a name="facing" val="north"/>
-    </comp>
-    <comp lib="0" loc="(1090,270)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="3op"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(190,650)" name="Decoder">
-      <a name="select" val="3"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="0" loc="(1250,560)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="S"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="1" loc="(610,380)" name="AND Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(1310,140)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="N"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(1330,610)" name="Tunnel">
-      <a name="label" val="Z"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="2" loc="(680,820)" name="Multiplexer">
-      <a name="select" val="2"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
     </comp>
     <comp lib="0" loc="(240,280)" name="Tunnel">
       <a name="label" val="2op"/>
@@ -6252,20 +5907,435 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="bit14" val="none"/>
       <a name="bit15" val="0"/>
     </comp>
-    <comp lib="0" loc="(1130,910)" name="Tunnel">
-      <a name="label" val="V"/>
+    <comp lib="0" loc="(1010,900)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(960,160)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="adder_carry"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="1" loc="(940,70)" name="OR Gate">
+    <comp loc="(640,620)" name="adder16">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(290,780)" name="Tunnel">
+      <a name="label" val="shra"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,570)" name="Tunnel">
+      <a name="label" val="not"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(850,130)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp loc="(600,1000)" name="barrel_shifter">
+      <a name="facing" val="north"/>
+    </comp>
+    <comp lib="0" loc="(170,660)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="2op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1310,140)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="N"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(630,1010)" name="Tunnel">
+      <a name="label" val="shifter_c"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1090,330)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="3op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(610,460)" name="XOR Gate">
+      <a name="width" val="16"/>
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
+    </comp>
+    <comp loc="(1300,610)" name="zero16"/>
+    <comp lib="0" loc="(290,800)" name="Tunnel">
+      <a name="label" val="rol"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1030,300)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1070,680)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(690,820)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="unary_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(960,150)" name="OR Gate">
+      <a name="facing" val="south"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="0" loc="(290,470)" name="Tunnel">
+      <a name="label" val="adc"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1050,570)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="unary_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(660,860)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(600,600)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(890,90)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(290,590)" name="Tunnel">
+      <a name="label" val="sxt"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1310,80)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="C"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(680,820)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="1" loc="(610,420)" name="OR Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1050,550)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="adder_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(640,590)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="adder_carry"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(200,170)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(890,50)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1110,590)" name="Tunnel">
+      <a name="width" val="2"/>
+      <a name="label" val="encoded_type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,390)" name="Tunnel">
+      <a name="label" val="or"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,610)" name="Tunnel">
+      <a name="label" val="scl"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(1220,1710)" name="NOT Gate"/>
+    <comp lib="0" loc="(600,1030)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
     <comp lib="1" loc="(560,650)" name="NOT Gate">
       <a name="width" val="16"/>
     </comp>
+    <comp lib="0" loc="(190,140)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="Cin"/>
+    </comp>
+    <comp lib="0" loc="(490,70)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="A"/>
+    </comp>
+    <comp lib="0" loc="(490,130)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="B"/>
+    </comp>
+    <comp lib="0" loc="(1070,760)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="label" val="shifter_c"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(170,680)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1050,530)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="logic_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(580,570)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="neg"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,410)" name="Tunnel">
+      <a name="label" val="xor"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1310,100)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="V"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(660,860)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="none"/>
+    </comp>
+    <comp lib="2" loc="(1220,320)" name="Priority Encoder">
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="2" loc="(190,470)" name="Decoder">
+      <a name="select" val="3"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="0" loc="(290,840)" name="Tunnel">
+      <a name="label" val="rcl"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(750,430)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="logic_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,470)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="1"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="none"/>
+    </comp>
+    <comp lib="0" loc="(170,850)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="shifts"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1310,140)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="N"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(170,480)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="3op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(610,500)" name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(1130,320)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(1310,80)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="C"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="2" loc="(740,430)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(470,470)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="B"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(210,1010)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="shift_count"/>
+    </comp>
+    <comp lib="1" loc="(560,610)" name="NOT Gate">
+      <a name="width" val="16"/>
+    </comp>
+    <comp lib="0" loc="(1010,740)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="adder_c"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,860)" name="Tunnel">
+      <a name="label" val="rcr"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(470,450)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="A"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1050,590)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="width" val="16"/>
+      <a name="label" val="shifter_out"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="2" loc="(1120,730)" name="Multiplexer">
+      <a name="select" val="2"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(500,130)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="B"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1090,360)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="2op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1250,560)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="S"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(610,380)" name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(1050,910)" name="Multiplexer">
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(290,740)" name="Tunnel">
+      <a name="label" val="shl"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(240,260)" name="Tunnel">
+      <a name="label" val="3op"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,370)" name="Tunnel">
+      <a name="label" val="and"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,550)" name="Tunnel">
+      <a name="label" val="neg"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(600,970)" name="Tunnel">
+      <a name="facing" val="south"/>
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1010,720)" name="Constant">
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(810,70)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(200,280)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="1" loc="(1090,290)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp loc="(570,870)" name="make_byte"/>
+    <comp lib="0" loc="(190,280)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="op_type"/>
+    </comp>
     <comp lib="0" loc="(1110,760)" name="Tunnel">
       <a name="width" val="2"/>
       <a name="label" val="encoded_type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,470)" name="Tunnel">
+      <a name="facing" val="north"/>
+      <a name="width" val="3"/>
+      <a name="label" val="func"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,820)" name="Tunnel">
+      <a name="label" val="ror"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="1" loc="(2850,390)" name="NOT Gate"/>
+    <comp lib="0" loc="(1330,640)" name="Tunnel">
+      <a name="label" val="N"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(290,760)" name="Tunnel">
+      <a name="label" val="shr"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1330,610)" name="Tunnel">
+      <a name="label" val="Z"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1310,120)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="Z"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(1210,520)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="16"/>
+    </comp>
+    <comp lib="0" loc="(670,610)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="adder_out"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
   </circuit>
@@ -6391,259 +6461,6 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(910,600)" to="(1040,600)"/>
     <wire from="(150,180)" to="(160,180)"/>
     <wire from="(610,1140)" to="(610,1330)"/>
-    <comp lib="3" loc="(680,1510)" name="Shifter">
-      <a name="width" val="17"/>
-      <a name="shift" val="rl"/>
-    </comp>
-    <comp lib="0" loc="(220,290)" name="Bit Extender">
-      <a name="in_width" val="3"/>
-      <a name="out_width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(580,910)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(1110,390)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="width" val="16"/>
-      <a name="label" val="Out"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(760,720)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(560,1580)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(150,120)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="In"/>
-    </comp>
-    <comp lib="0" loc="(1110,620)" name="Pin">
-      <a name="facing" val="west"/>
-      <a name="output" val="true"/>
-      <a name="label" val="cout"/>
-      <a name="labelloc" val="east"/>
-    </comp>
-    <comp lib="0" loc="(720,710)" name="Splitter">
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(660,1330)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-    </comp>
-    <comp lib="0" loc="(230,340)" name="Constant">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="0" loc="(580,1710)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="2" loc="(1080,620)" name="Multiplexer">
-      <a name="select" val="3"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="3" loc="(700,1130)" name="Shifter">
-      <a name="width" val="16"/>
-      <a name="shift" val="rl"/>
-    </comp>
-    <comp lib="0" loc="(160,180)" name="Tunnel">
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(150,180)" name="Pin">
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="cin"/>
-    </comp>
-    <comp lib="0" loc="(1070,440)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="0" loc="(620,1330)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="5"/>
-      <a name="appear" val="right"/>
-      <a name="bit4" val="none"/>
-    </comp>
-    <comp lib="0" loc="(580,1500)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(720,1720)" name="Splitter">
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(160,120)" name="Tunnel">
-      <a name="width" val="16"/>
-      <a name="label" val="value"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="3" loc="(680,920)" name="Shifter">
-      <a name="width" val="17"/>
-      <a name="shift" val="ar"/>
-    </comp>
-    <comp lib="0" loc="(150,230)" name="Pin">
-      <a name="width" val="3"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="shift_type"/>
-    </comp>
-    <comp lib="0" loc="(760,1730)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(760,1510)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="2" loc="(1080,390)" name="Multiplexer">
-      <a name="select" val="3"/>
-      <a name="width" val="16"/>
-      <a name="enable" val="false"/>
-    </comp>
-    <comp lib="0" loc="(580,700)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(540,920)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(150,290)" name="Pin">
-      <a name="width" val="3"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="distance"/>
-    </comp>
-    <comp lib="0" loc="(660,1140)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-    </comp>
-    <comp lib="0" loc="(720,920)" name="Splitter">
-      <a name="fanout" val="17"/>
-      <a name="incoming" val="17"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(560,1630)" name="Tunnel">
-      <a name="facing" val="east"/>
-      <a name="label" val="cin"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(659,680)" name="Text">
-      <a name="text" val="shr"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="6" loc="(658,465)" name="Text">
-      <a name="text" val="shl"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="3" loc="(310,300)" name="Adder">
-      <a name="width" val="5"/>
-    </comp>
-    <comp lib="6" loc="(659,890)" name="Text">
-      <a name="text" val="shra"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="0" loc="(160,230)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="type"/>
-      <a name="labelfont" val="SansSerif plain 9"/>
-    </comp>
-    <comp lib="6" loc="(681,1292)" name="Text">
-      <a name="text" val="ror"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="3" loc="(680,500)" name="Shifter">
-      <a name="width" val="17"/>
-    </comp>
-    <comp lib="0" loc="(760,930)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="3" loc="(680,1720)" name="Shifter">
-      <a name="width" val="17"/>
-      <a name="shift" val="rr"/>
-    </comp>
-    <comp lib="0" loc="(620,1140)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="5"/>
-      <a name="appear" val="right"/>
-      <a name="bit4" val="none"/>
-    </comp>
-    <comp lib="0" loc="(540,1500)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(540,1720)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(760,1160)" name="Splitter">
-      <a name="fanout" val="1"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-      <a name="bit1" val="none"/>
-      <a name="bit2" val="none"/>
-      <a name="bit3" val="none"/>
-      <a name="bit4" val="none"/>
-      <a name="bit5" val="none"/>
-      <a name="bit6" val="none"/>
-      <a name="bit7" val="none"/>
-      <a name="bit8" val="none"/>
-      <a name="bit9" val="none"/>
-      <a name="bit10" val="none"/>
-      <a name="bit11" val="none"/>
-      <a name="bit12" val="none"/>
-      <a name="bit13" val="none"/>
-      <a name="bit14" val="none"/>
-      <a name="bit15" val="none"/>
-    </comp>
-    <comp lib="6" loc="(660,1477)" name="Text">
-      <a name="text" val="rcl"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="6" loc="(659,1689)" name="Text">
-      <a name="text" val="rcr"/>
-      <a name="font" val="SansSerif bold 14"/>
-    </comp>
-    <comp lib="0" loc="(760,500)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
     <comp lib="0" loc="(760,1350)" name="Splitter">
       <a name="fanout" val="1"/>
       <a name="incoming" val="16"/>
@@ -6665,10 +6482,112 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="bit14" val="none"/>
       <a name="bit15" val="0"/>
     </comp>
+    <comp lib="6" loc="(659,890)" name="Text">
+      <a name="text" val="shra"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="6" loc="(682,1100)" name="Text">
+      <a name="text" val="rol"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="3" loc="(680,1510)" name="Shifter">
+      <a name="width" val="17"/>
+      <a name="shift" val="rl"/>
+    </comp>
+    <comp lib="3" loc="(680,710)" name="Shifter">
+      <a name="width" val="17"/>
+      <a name="shift" val="lr"/>
+    </comp>
+    <comp lib="6" loc="(658,465)" name="Text">
+      <a name="text" val="shl"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="0" loc="(760,1730)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(620,1140)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="5"/>
+      <a name="appear" val="right"/>
+      <a name="bit4" val="none"/>
+    </comp>
+    <comp lib="0" loc="(580,1710)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(540,1500)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(150,180)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="cin"/>
+    </comp>
+    <comp lib="0" loc="(220,290)" name="Bit Extender">
+      <a name="in_width" val="3"/>
+      <a name="out_width" val="5"/>
+    </comp>
+    <comp lib="0" loc="(560,1630)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(160,230)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(580,1500)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
     <comp lib="0" loc="(720,1510)" name="Splitter">
       <a name="fanout" val="17"/>
       <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
+    </comp>
+    <comp lib="3" loc="(700,1320)" name="Shifter">
+      <a name="width" val="16"/>
+      <a name="shift" val="rr"/>
+    </comp>
+    <comp lib="0" loc="(160,180)" name="Tunnel">
+      <a name="label" val="cin"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,1720)" name="Splitter">
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(540,710)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="6" loc="(660,1477)" name="Text">
+      <a name="text" val="rcl"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="0" loc="(230,340)" name="Constant">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="3" loc="(680,500)" name="Shifter">
+      <a name="width" val="17"/>
+    </comp>
+    <comp lib="0" loc="(150,290)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="distance"/>
     </comp>
     <comp lib="0" loc="(310,440)" name="Tunnel">
       <a name="facing" val="east"/>
@@ -6676,24 +6595,56 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="value"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(540,710)" name="Splitter">
+    <comp lib="0" loc="(760,500)" name="Splitter">
+      <a name="facing" val="west"/>
       <a name="fanout" val="16"/>
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(1070,670)" name="Tunnel">
-      <a name="width" val="3"/>
-      <a name="label" val="type"/>
+    <comp lib="0" loc="(580,910)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(540,920)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(560,1580)" name="Tunnel">
+      <a name="facing" val="east"/>
+      <a name="label" val="cin"/>
       <a name="labelfont" val="SansSerif plain 9"/>
     </comp>
-    <comp lib="0" loc="(540,490)" name="Splitter">
-      <a name="fanout" val="16"/>
+    <comp lib="0" loc="(760,1160)" name="Splitter">
+      <a name="fanout" val="1"/>
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
+      <a name="bit1" val="none"/>
+      <a name="bit2" val="none"/>
+      <a name="bit3" val="none"/>
+      <a name="bit4" val="none"/>
+      <a name="bit5" val="none"/>
+      <a name="bit6" val="none"/>
+      <a name="bit7" val="none"/>
+      <a name="bit8" val="none"/>
+      <a name="bit9" val="none"/>
+      <a name="bit10" val="none"/>
+      <a name="bit11" val="none"/>
+      <a name="bit12" val="none"/>
+      <a name="bit13" val="none"/>
+      <a name="bit14" val="none"/>
+      <a name="bit15" val="none"/>
     </comp>
-    <comp lib="3" loc="(700,1320)" name="Shifter">
-      <a name="width" val="16"/>
-      <a name="shift" val="rr"/>
+    <comp lib="3" loc="(680,920)" name="Shifter">
+      <a name="width" val="17"/>
+      <a name="shift" val="ar"/>
+    </comp>
+    <comp lib="0" loc="(720,920)" name="Splitter">
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(580,490)" name="Splitter">
       <a name="facing" val="west"/>
@@ -6701,18 +6652,137 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="6" loc="(682,1100)" name="Text">
-      <a name="text" val="rol"/>
+    <comp lib="3" loc="(680,1720)" name="Shifter">
+      <a name="width" val="17"/>
+      <a name="shift" val="rr"/>
+    </comp>
+    <comp lib="0" loc="(620,1330)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="5"/>
+      <a name="appear" val="right"/>
+      <a name="bit4" val="none"/>
+    </comp>
+    <comp lib="0" loc="(160,120)" name="Tunnel">
+      <a name="width" val="16"/>
+      <a name="label" val="value"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(760,720)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(580,700)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(540,1720)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="6" loc="(659,680)" name="Text">
+      <a name="text" val="shr"/>
       <a name="font" val="SansSerif bold 14"/>
     </comp>
-    <comp lib="3" loc="(680,710)" name="Shifter">
-      <a name="width" val="17"/>
-      <a name="shift" val="lr"/>
+    <comp lib="3" loc="(700,1130)" name="Shifter">
+      <a name="width" val="16"/>
+      <a name="shift" val="rl"/>
+    </comp>
+    <comp lib="0" loc="(660,1140)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+    </comp>
+    <comp lib="6" loc="(681,1292)" name="Text">
+      <a name="text" val="ror"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="0" loc="(150,120)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="In"/>
+    </comp>
+    <comp lib="0" loc="(1070,670)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(1070,440)" name="Tunnel">
+      <a name="width" val="3"/>
+      <a name="label" val="type"/>
+      <a name="labelfont" val="SansSerif plain 9"/>
+    </comp>
+    <comp lib="0" loc="(720,710)" name="Splitter">
+      <a name="fanout" val="17"/>
+      <a name="incoming" val="17"/>
+      <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(720,500)" name="Splitter">
       <a name="fanout" val="17"/>
       <a name="incoming" val="17"/>
       <a name="appear" val="center"/>
+    </comp>
+    <comp lib="3" loc="(310,300)" name="Adder">
+      <a name="width" val="5"/>
+    </comp>
+    <comp lib="6" loc="(659,1689)" name="Text">
+      <a name="text" val="rcr"/>
+      <a name="font" val="SansSerif bold 14"/>
+    </comp>
+    <comp lib="0" loc="(540,490)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(760,1510)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(1110,390)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="16"/>
+      <a name="label" val="Out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(150,230)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="shift_type"/>
+    </comp>
+    <comp lib="0" loc="(760,930)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="2" loc="(1080,390)" name="Multiplexer">
+      <a name="select" val="3"/>
+      <a name="width" val="16"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(1110,620)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="cout"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(660,1330)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+    </comp>
+    <comp lib="2" loc="(1080,620)" name="Multiplexer">
+      <a name="select" val="3"/>
+      <a name="enable" val="false"/>
     </comp>
   </circuit>
   <circuit name="adder16">
@@ -6804,62 +6874,22 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(750,340)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
+    <comp lib="0" loc="(230,220)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="A"/>
+    </comp>
+    <comp lib="1" loc="(550,240)" name="XOR Gate">
+      <a name="width" val="16"/>
+      <a name="inputs" val="3"/>
+      <a name="xor" val="odd"/>
     </comp>
     <comp lib="0" loc="(800,610)" name="Pin">
       <a name="facing" val="north"/>
       <a name="output" val="true"/>
       <a name="label" val="V"/>
       <a name="labelloc" val="south"/>
-    </comp>
-    <comp lib="1" loc="(510,310)" name="AND Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(780,540)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(760,220)" name="Probe">
-      <a name="facing" val="south"/>
-      <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="1" loc="(510,390)" name="AND Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(510,350)" name="AND Gate">
-      <a name="width" val="16"/>
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="0" loc="(690,120)" name="Pin">
-      <a name="facing" val="south"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="Cin"/>
-    </comp>
-    <comp lib="0" loc="(230,260)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="B"/>
-    </comp>
-    <comp lib="0" loc="(270,270)" name="Probe">
-      <a name="facing" val="north"/>
-      <a name="radix" val="10signed"/>
-    </comp>
-    <comp lib="0" loc="(230,220)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="pull" val="down"/>
-      <a name="label" val="A"/>
     </comp>
     <comp lib="0" loc="(700,610)" name="Pin">
       <a name="facing" val="north"/>
@@ -6871,11 +6901,6 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="width" val="16"/>
       <a name="inputs" val="3"/>
     </comp>
-    <comp lib="1" loc="(550,240)" name="XOR Gate">
-      <a name="width" val="16"/>
-      <a name="inputs" val="3"/>
-      <a name="xor" val="odd"/>
-    </comp>
     <comp lib="0" loc="(800,240)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -6884,9 +6909,54 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="S"/>
       <a name="labelloc" val="east"/>
     </comp>
+    <comp lib="1" loc="(510,390)" name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(760,220)" name="Probe">
+      <a name="facing" val="south"/>
+      <a name="radix" val="10signed"/>
+    </comp>
+    <comp lib="0" loc="(270,270)" name="Probe">
+      <a name="facing" val="north"/>
+      <a name="radix" val="10signed"/>
+    </comp>
+    <comp lib="1" loc="(510,310)" name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(690,120)" name="Pin">
+      <a name="facing" val="south"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="Cin"/>
+    </comp>
+    <comp lib="1" loc="(510,350)" name="AND Gate">
+      <a name="width" val="16"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
     <comp lib="0" loc="(270,210)" name="Probe">
       <a name="facing" val="south"/>
       <a name="radix" val="10signed"/>
+    </comp>
+    <comp lib="0" loc="(750,340)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="1" loc="(780,540)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(230,260)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="pull" val="down"/>
+      <a name="label" val="B"/>
     </comp>
   </circuit>
   <circuit name="branch_logic">
@@ -7004,53 +7074,123 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(820,540)" to="(960,540)"/>
     <wire from="(420,330)" to="(420,390)"/>
     <wire from="(1110,440)" to="(1110,610)"/>
-    <comp lib="1" loc="(250,340)" name="NOT Gate">
-      <a name="size" val="20"/>
-    </comp>
-    <comp lib="6" loc="(642,362)" name="Text">
-      <a name="text" val="MI"/>
+    <comp lib="6" loc="(1016,443)" name="Text">
+      <a name="text" val="HI"/>
       <a name="font" val="SansSerif plain 18"/>
     </comp>
-    <comp lib="1" loc="(540,340)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="6" loc="(644,392)" name="Text">
+      <a name="text" val="VS"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="6" loc="(643,302)" name="Text">
+      <a name="text" val="EQ"/>
+      <a name="font" val="SansSerif plain 18"/>
     </comp>
     <comp lib="1" loc="(600,400)" name="AND Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
+    <comp lib="6" loc="(642,362)" name="Text">
+      <a name="text" val="MI"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="1" loc="(620,600)" name="NOT Gate"/>
+    <comp lib="1" loc="(990,460)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="1" loc="(990,610)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="3"/>
+    </comp>
+    <comp lib="6" loc="(643,335)" name="Text">
+      <a name="text" val="HS/CS"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
     <comp lib="6" loc="(330,563)" name="Text">
       <a name="text" val="N"/>
       <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="1" loc="(1280,290)" name="XOR Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="2" loc="(740,450)" name="Decoder">
+      <a name="selloc" val="tr"/>
+      <a name="select" val="2"/>
+      <a name="disabled" val="0"/>
+    </comp>
+    <comp lib="6" loc="(1016,600)" name="Text">
+      <a name="text" val="GT"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="0" loc="(160,320)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
     </comp>
     <comp lib="6" loc="(756,541)" name="Text">
       <a name="text" val="N=V"/>
       <a name="font" val="SansSerif plain 18"/>
     </comp>
-    <comp lib="0" loc="(160,610)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
     <comp lib="2" loc="(370,340)" name="Decoder">
       <a name="select" val="2"/>
       <a name="disabled" val="0"/>
     </comp>
-    <comp lib="6" loc="(330,594)" name="Text">
-      <a name="text" val="Z"/>
-      <a name="font" val="SansSerif plain 18"/>
+    <comp lib="1" loc="(990,530)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(250,340)" name="NOT Gate">
+      <a name="size" val="20"/>
+    </comp>
+    <comp lib="1" loc="(540,340)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(200,320)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="appear" val="center"/>
     </comp>
     <comp lib="1" loc="(700,520)" name="XNOR Gate">
       <a name="size" val="30"/>
       <a name="inputs" val="2"/>
     </comp>
+    <comp lib="6" loc="(744,594)" name="Text">
+      <a name="text" val="Z'"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
     <comp lib="6" loc="(330,623)" name="Text">
       <a name="text" val="V"/>
       <a name="font" val="SansSerif plain 18"/>
     </comp>
-    <comp lib="0" loc="(200,320)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="appear" val="center"/>
+    <comp lib="6" loc="(1014,518)" name="Text">
+      <a name="text" val="GE"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="1" loc="(1210,410)" name="OR Gate">
+      <a name="inputs" val="8"/>
+    </comp>
+    <comp lib="1" loc="(570,370)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(120,320)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="cccc"/>
+    </comp>
+    <comp lib="6" loc="(328,653)" name="Text">
+      <a name="text" val="C"/>
+      <a name="font" val="SansSerif plain 18"/>
+    </comp>
+    <comp lib="1" loc="(510,310)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="6" loc="(330,594)" name="Text">
+      <a name="text" val="Z"/>
+      <a name="font" val="SansSerif plain 18"/>
     </comp>
     <comp lib="0" loc="(1300,290)" name="Pin">
       <a name="facing" val="west"/>
@@ -7059,88 +7199,18 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="go"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="1" loc="(990,460)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="1" loc="(1210,410)" name="OR Gate">
-      <a name="inputs" val="8"/>
-    </comp>
-    <comp lib="2" loc="(740,450)" name="Decoder">
-      <a name="selloc" val="tr"/>
-      <a name="select" val="2"/>
-      <a name="disabled" val="0"/>
-    </comp>
-    <comp lib="6" loc="(1014,518)" name="Text">
-      <a name="text" val="GE"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="1" loc="(510,310)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(620,600)" name="NOT Gate"/>
-    <comp lib="6" loc="(644,392)" name="Text">
-      <a name="text" val="VS"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="1" loc="(1280,290)" name="XOR Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="1" loc="(990,610)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="3"/>
-    </comp>
-    <comp lib="6" loc="(1016,600)" name="Text">
-      <a name="text" val="GT"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="1" loc="(990,530)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="6" loc="(643,335)" name="Text">
-      <a name="text" val="HS/CS"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="6" loc="(328,653)" name="Text">
-      <a name="text" val="C"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="1" loc="(570,370)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
-    </comp>
-    <comp lib="6" loc="(643,302)" name="Text">
-      <a name="text" val="EQ"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="6" loc="(1025,678)" name="Text">
-      <a name="text" val="&lt;always&gt;"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="0" loc="(160,320)" name="Splitter">
-      <a name="fanout" val="4"/>
-      <a name="incoming" val="4"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="6" loc="(1016,443)" name="Text">
-      <a name="text" val="HI"/>
-      <a name="font" val="SansSerif plain 18"/>
-    </comp>
-    <comp lib="0" loc="(120,320)" name="Pin">
-      <a name="width" val="4"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="cccc"/>
-    </comp>
     <comp lib="0" loc="(120,610)" name="Pin">
       <a name="width" val="4"/>
       <a name="tristate" val="false"/>
       <a name="label" val="CVZN"/>
     </comp>
-    <comp lib="6" loc="(744,594)" name="Text">
-      <a name="text" val="Z'"/>
+    <comp lib="0" loc="(160,610)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="4"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="6" loc="(1025,678)" name="Text">
+      <a name="text" val="&lt;always&gt;"/>
       <a name="font" val="SansSerif plain 18"/>
     </comp>
   </circuit>
@@ -7213,21 +7283,22 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(360,390)" to="(440,390)"/>
     <wire from="(490,360)" to="(570,360)"/>
     <wire from="(560,390)" to="(570,390)"/>
+    <comp lib="1" loc="(700,330)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
     <comp lib="1" loc="(630,280)" name="NOR Gate">
       <a name="inputs" val="8"/>
-    </comp>
-    <comp lib="0" loc="(340,320)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(330,320)" name="Pin">
       <a name="width" val="16"/>
       <a name="tristate" val="false"/>
       <a name="label" val="in"/>
     </comp>
-    <comp lib="1" loc="(630,380)" name="NOR Gate">
-      <a name="inputs" val="8"/>
+    <comp lib="0" loc="(340,320)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
     </comp>
     <comp lib="0" loc="(720,330)" name="Pin">
       <a name="facing" val="west"/>
@@ -7235,9 +7306,8 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="zero"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="1" loc="(700,330)" name="AND Gate">
-      <a name="size" val="30"/>
-      <a name="inputs" val="2"/>
+    <comp lib="1" loc="(630,380)" name="NOR Gate">
+      <a name="inputs" val="8"/>
     </comp>
   </circuit>
   <circuit name="2s_compliment">
@@ -7260,15 +7330,15 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="tristate" val="false"/>
       <a name="label" val="In"/>
     </comp>
-    <comp lib="0" loc="(580,500)" name="Bit Extender">
-      <a name="type" val="sign"/>
-    </comp>
     <comp lib="0" loc="(590,500)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
       <a name="width" val="16"/>
       <a name="label" val="Out"/>
       <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(580,500)" name="Bit Extender">
+      <a name="type" val="sign"/>
     </comp>
     <comp lib="0" loc="(530,500)" name="Bit Extender">
       <a name="in_width" val="16"/>
@@ -7290,15 +7360,11 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(480,500)" to="(490,500)"/>
     <wire from="(530,500)" to="(540,500)"/>
     <wire from="(580,500)" to="(590,500)"/>
-    <comp lib="0" loc="(480,500)" name="Pin">
-      <a name="width" val="16"/>
-      <a name="tristate" val="false"/>
-      <a name="label" val="In"/>
-    </comp>
     <comp lib="0" loc="(530,500)" name="Bit Extender">
       <a name="in_width" val="16"/>
       <a name="out_width" val="8"/>
     </comp>
+    <comp lib="0" loc="(580,500)" name="Bit Extender"/>
     <comp lib="0" loc="(590,500)" name="Pin">
       <a name="facing" val="west"/>
       <a name="output" val="true"/>
@@ -7306,7 +7372,11 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="label" val="Out"/>
       <a name="labelloc" val="east"/>
     </comp>
-    <comp lib="0" loc="(580,500)" name="Bit Extender"/>
+    <comp lib="0" loc="(480,500)" name="Pin">
+      <a name="width" val="16"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="In"/>
+    </comp>
   </circuit>
   <circuit name="bytes_swap">
     <a name="circuit" val="bytes_swap"/>
@@ -7330,22 +7400,6 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
     <wire from="(570,550)" to="(580,550)"/>
     <wire from="(520,510)" to="(530,510)"/>
     <wire from="(600,470)" to="(610,470)"/>
-    <comp lib="0" loc="(570,550)" name="Splitter">
-      <a name="facing" val="west"/>
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(610,470)" name="Splitter">
-      <a name="fanout" val="8"/>
-      <a name="incoming" val="8"/>
-      <a name="appear" val="center"/>
-    </comp>
-    <comp lib="0" loc="(530,510)" name="Splitter">
-      <a name="fanout" val="16"/>
-      <a name="incoming" val="16"/>
-      <a name="appear" val="center"/>
-    </comp>
     <comp lib="0" loc="(610,550)" name="Splitter">
       <a name="fanout" val="8"/>
       <a name="incoming" val="8"/>
@@ -7364,7 +7418,17 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="incoming" val="16"/>
       <a name="appear" val="center"/>
     </comp>
-    <comp lib="0" loc="(570,470)" name="Splitter">
+    <comp lib="0" loc="(610,470)" name="Splitter">
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(530,510)" name="Splitter">
+      <a name="fanout" val="16"/>
+      <a name="incoming" val="16"/>
+      <a name="appear" val="center"/>
+    </comp>
+    <comp lib="0" loc="(570,550)" name="Splitter">
       <a name="facing" val="west"/>
       <a name="fanout" val="8"/>
       <a name="incoming" val="8"/>
@@ -7374,6 +7438,12 @@ c038082 8038082 8*0 c080980 804a001 801a000 805a001 8000949
       <a name="width" val="16"/>
       <a name="tristate" val="false"/>
       <a name="label" val="In"/>
+    </comp>
+    <comp lib="0" loc="(570,470)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="8"/>
+      <a name="incoming" val="8"/>
+      <a name="appear" val="center"/>
     </comp>
   </circuit>
 </project>


### PR DESCRIPTION
Fix the situation when `PC` could be rolled back when handling exception even if the instruction was virtual.