### PR TITLE
Change debug export format

### DIFF
--- a/cocas/debug_export.py
+++ b/cocas/debug_export.py
@@ -1,0 +1,35 @@
+import bisect
+import json
+import re
+
+from cocas.location import CodeLocation
+
+
+def default_json_(o, files):
+    # if some json object should be in one line, without \n, wrap it with these __no_breaks
+    # do not cascade __no_breaks, regex will break (e.g. {begin, {begin, ..., end}, end}
+    if isinstance(o, CodeLocation):
+        return {
+            "__no_breaks_begin": [],
+            "f": bisect.bisect_left(files, o.file), "l": o.line, "c": o.column,
+            "__no_breaks_end": []
+        }
+    else:
+        raise TypeError(f'Object of type {o.__class__.__name__} '
+                        f'is not JSON serializable')
+
+
+def default_json(files):
+    return lambda x: default_json_(x, files)
+
+
+def code_location_json(files, cl: CodeLocation):
+    return {"f": bisect.bisect_left(files, cl.file), "l": cl.line, "c": cl.column}
+
+
+def debug_export(code_locations: dict[int, CodeLocation]) -> str:
+    files = sorted(set(map(lambda x: x.file, code_locations.values())))
+    dump = json.dumps({"files": files, "codeLocations": code_locations}, default=default_json(files), indent=4)
+    pattern = re.compile(r"{\n\s+\"__no_breaks_begin\": \[],\n\s+([\S\s]+?),\n\s+\"__no_breaks_end\": \[]\s+}")
+    dump = re.sub(pattern, lambda m: "{" + re.sub(r"\n\s+", " ", m.group(1)) + "}", dump)
+    return dump

--- a/cocas/debug_export.py
+++ b/cocas/debug_export.py
@@ -29,7 +29,8 @@ def code_location_json(files, cl: CodeLocation):
 
 def debug_export(code_locations: dict[int, CodeLocation]) -> str:
     files = sorted(set(map(lambda x: x.file, code_locations.values())))
-    dump = json.dumps({"files": files, "codeLocations": code_locations}, default=default_json(files), indent=4)
+    dump = json.dumps({"files": files, "codeLocations": code_locations},
+                      default=default_json(files), indent=4, ensure_ascii=False)
     pattern = re.compile(r"{\n\s+\"__no_breaks_begin\": \[],\n\s+([\S\s]+?),\n\s+\"__no_breaks_end\": \[]\s+}")
     dump = re.sub(pattern, lambda m: "{" + re.sub(r"\n\s+", " ", m.group(1)) + "}", dump)
     return dump

--- a/cocas/main.py
+++ b/cocas/main.py
@@ -66,7 +66,7 @@ def main():
     parser.add_argument('-m', '--merge', action='store_true', help='merge object files into one')
     parser.add_argument('-o', '--output', type=str, help='specify output file name')
     debug_group = parser.add_argument_group('debug')
-    debug_group.add_argument('--debug', type=str, nargs='?', const='out.dbg.json', help='export debug information')
+    debug_group.add_argument('--debug', type=str, nargs='?', const=True, help='export debug information')
     debug_path_group = debug_group.add_mutually_exclusive_group()
     debug_path_group.add_argument('--relative-path', type=pathlib.Path,
                                   help='convert source files paths to relative in debug info and object files')
@@ -253,10 +253,17 @@ def main():
             handle_os_error(e)
 
         if args.debug:
+            if args.debug is True:
+                if args.output:
+                    filename = pathlib.Path(args.output).with_suffix('.dbg.json')
+                else:
+                    filename = 'out.dbg.json'
+            else:
+                filename = args.debug
             code_locations = {key: value for (key, value) in sorted(code_locations.items())}
             debug_info = debug_export(code_locations)
             try:
-                with open(args.debug, 'w') as f:
+                with open(filename, 'w') as f:
                     f.write(debug_info)
             except OSError as e:
                 handle_os_error(e)

--- a/cocas/main.py
+++ b/cocas/main.py
@@ -1,11 +1,9 @@
 import argparse
 import codecs
 import importlib
-import json
 import os
 import pathlib
 import pkgutil
-from dataclasses import asdict
 from typing import Union
 
 import antlr4
@@ -13,6 +11,7 @@ import colorama
 
 from cocas.assembler import assemble
 from cocas.ast_builder import build_ast
+from cocas.debug_export import debug_export
 from cocas.error import CdmException, CdmExceptionTag, CdmLinkException, log_error
 from cocas.linker import link
 from cocas.macro_processor import process_macros, read_mlb
@@ -254,11 +253,11 @@ def main():
             handle_os_error(e)
 
         if args.debug:
-            code_locations = {key: asdict(loc) for key, loc in code_locations.items()}
-            json_locations = json.dumps(code_locations, indent=4, sort_keys=True)
+            code_locations = {key: value for (key, value) in sorted(code_locations.items())}
+            debug_info = debug_export(code_locations)
             try:
                 with open(args.debug, 'w') as f:
-                    f.write(json_locations)
+                    f.write(debug_info)
             except OSError as e:
                 handle_os_error(e)
 


### PR DESCRIPTION
```json
{
    "files": [
        "first.asm",
        "second.asm"
    ],
    "code_locations": {
        "1321": { "f":0, "l":5, "c":0 },
        "1322": { "f":0, "l":6, "c":0 },
        "1323": { "f":1, "l":7, "c":0 },
        "1324": { "f":1, "l":8, "c":0 }
    }
}
```
In future, this format can be extended with more top-level values