### PR TITLE
Fix comments in VS Code extension

### DIFF
--- a/vscode-cdm-extension/languages/assembly-language-configuration.json
+++ b/vscode-cdm-extension/languages/assembly-language-configuration.json
@@ -1,9 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "lineComment": "#"
     },
     // symbols used as brackets
     "brackets": [

--- a/vscode-cdm-extension/syntaxes/cdm16-assembly.tmLanguage.json
+++ b/vscode-cdm-extension/syntaxes/cdm16-assembly.tmLanguage.json
@@ -60,12 +60,7 @@
         "comments": {
 			"patterns": [{
 				"name": "comment.line",
-				"match": "(//|#).*$"
-			},
-            {
-				"name": "comment.block",
-				"begin": "/\\*",
-                "end": "\\*/"
+				"match": "(#).*$"
 			}]
 		},
 		"macros": {

--- a/vscode-cdm-extension/syntaxes/cdm8-assembly.tmLanguage.json
+++ b/vscode-cdm-extension/syntaxes/cdm8-assembly.tmLanguage.json
@@ -60,12 +60,7 @@
         "comments": {
 			"patterns": [{
 				"name": "comment.line",
-				"match": "(//|#).*$"
-			},
-            {
-				"name": "comment.block",
-				"begin": "/\\*",
-                "end": "\\*/"
+				"match": "(#).*$"
 			}]
 		},
         "macros": {

--- a/vscode-cdm-extension/syntaxes/cdm8e-assembly.tmLanguage.json
+++ b/vscode-cdm-extension/syntaxes/cdm8e-assembly.tmLanguage.json
@@ -60,12 +60,7 @@
         "comments": {
 			"patterns": [{
 				"name": "comment.line",
-				"match": "(//|#).*$"
-			},
-            {
-				"name": "comment.block",
-				"begin": "/\\*",
-                "end": "\\*/"
+				"match": "(#).*$"
 			}]
 		},
         "macros": {


### PR DESCRIPTION
Fixes line comments and removes block comments at language and syntax definitions.

Closes #63.