### PR TITLE
Fix `shla` decoding for CdM-8 in `cocodump`

### DIFF
--- a/cocodump/targets/cdm8/asm.py
+++ b/cocodump/targets/cdm8/asm.py
@@ -22,7 +22,7 @@ inst_decoders: dict[InstructionGroup | int, InstructionDecoder] = {
 
     InstructionGroup.UNARY_ARITH: InstructionDecoder({0: "not", 1: "neg", 2: "dec", 3: "inc"}),
 
-    InstructionGroup.SHIFTS: InstructionDecoder({0: "shr", 1: "shl", 2: "shra", 3: "rol"}),
+    InstructionGroup.SHIFTS: InstructionDecoder({0: "shr", 1: "shla", 2: "shra", 3: "rol"}),
 
     InstructionGroup.PUSH_GR: InstructionDecoder({0: "push", 1: "pop", 2: "ldsa"}),
 


### PR DESCRIPTION
Change decoding table for CdM-8 so it correctly decodes `shla`.

Fix #60 