### PR TITLE
Fix test failures due to missing `.img` suffix

### DIFF
--- a/tests/factory/collector.py
+++ b/tests/factory/collector.py
@@ -76,7 +76,7 @@ class Collector:
         Returns:
             An image, if assembler exited gracefully, ``None`` otherwise.
         """
-        image_file = NamedTemporaryFile(delete=False)
+        image_file = NamedTemporaryFile(suffix=".img", delete=False)
         image_file.close()
 
         process = subprocess.run([


### PR DESCRIPTION
#76 silently broke tests, as it made binary the default mode for image generation at `cocas`; this PR adds a `.img` suffix for generated paths, so `cocas` outputs images in Logisim format.