### PR TITLE
Fix BindError in `cocoemu-server` and `logisim-debugger`

### DIFF
--- a/cdp-java/src/main/java/org/cdm/debug/server/Server.java
+++ b/cdp-java/src/main/java/org/cdm/debug/server/Server.java
@@ -27,14 +27,16 @@ public class Server extends WebSocketServer {
     private WebSocket currentConnection;
 
     public Server(Supplier<MessageHandler> messageHandlerFactory) {
-        super(new InetSocketAddress(DEFAULT_PORT));
-
-        this.messageHandlerFactory = messageHandlerFactory;
+        this(DEFAULT_PORT, messageHandlerFactory);
     }
+
     public Server(int port, Supplier<MessageHandler> messageHandlerFactory) {
         super(new InetSocketAddress(port));
 
         this.messageHandlerFactory = messageHandlerFactory;
+
+        // Fix BindError
+        setReuseAddr(true);
     }
 
     public BlockingQueue<RawMessage> getMessageQueue() {

--- a/logisim/logisim-debugger/src/main/java/org/cdm/logisim/debugger/server/Server.java
+++ b/logisim/logisim-debugger/src/main/java/org/cdm/logisim/debugger/server/Server.java
@@ -22,6 +22,9 @@ public class Server extends WebSocketServer {
 
     public Server(int port) {
         super(new InetSocketAddress(port));
+
+        // Fix BindError
+        setReuseAddr(true);
     }
 
     @Override


### PR DESCRIPTION
As suggested by @cjvth, setting SO_REUSEADDR should fix BindError.

Closes #85