### PR TITLE
Reduce size of `logisim-debugger` jar

### DIFF
--- a/logisim/logisim-debugger/build.gradle
+++ b/logisim/logisim-debugger/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    compileOnly fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'org.java-websocket:Java-WebSocket:1.5.3'
     implementation 'org.slf4j:slf4j-nop:2.0.9'
     implementation 'com.google.code.gson:gson:2.10.1'


### PR DESCRIPTION
Reduce size of `logisim-debugger` jar by excluding logisim from runtime classpath.