### PR TITLE
Add support for Von Neumann architecture to `logisim-runner`

### DIFF
--- a/logisim/logisim-runner/src/main/java/org/cdm/logisim/runner/Main.java
+++ b/logisim/logisim-runner/src/main/java/org/cdm/logisim/runner/Main.java
@@ -21,6 +21,14 @@ public class Main {
     private static final int TIMEOUT = 4;
 
     public static void main(String[] args) {
+        if (args.length < 5) {
+            System.err.println("Invalid arguments");
+            System.err.println("Usage: logisim-runner.jar " +
+                    "[programImage] [circuit] [outputImage] [config] [timeout]"
+            );
+            System.exit(EXIT_FAILURE);
+        }
+
         Runner runner = new Runner();
 
         File imgFile = new File(args[IMG_FILE]);

--- a/logisim/logisim-runner/src/main/java/org/cdm/logisim/runner/MemoryArchitecture.java
+++ b/logisim/logisim-runner/src/main/java/org/cdm/logisim/runner/MemoryArchitecture.java
@@ -1,0 +1,19 @@
+package org.cdm.logisim.runner;
+
+public enum MemoryArchitecture {
+    VON_NEUMANN,
+    HARVARD;
+
+    public static MemoryArchitecture fromString(String string) {
+        string = string.toLowerCase().trim();
+
+        switch (string) {
+            case "vn":
+                return MemoryArchitecture.VON_NEUMANN;
+            case "hv":
+                return MemoryArchitecture.HARVARD;
+            default:
+                return null;
+        }
+    }
+}

--- a/logisim/logisim-runner/src/main/resources/example_config.properties
+++ b/logisim/logisim-runner/src/main/resources/example_config.properties
@@ -2,3 +2,4 @@
 
 pin_names = r0, r1, r2, r3, pc, ps, sp
 halt_pin = halted
+memory_architecture = vn


### PR DESCRIPTION
Add new field `memory_architecture` to config file. This field specifies what memory configuration test circuit uses. Valid values are `hv` for Harvard and `vn` for Von Neumann, default value is `hv`.

Implemented features:
- Support for Von Neumann architecture to `logisim-runner`
- Minimal CLI arguments validation