### PR TITLE
Handle `ValueError` when parsing string escape code in `cocas`

### DIFF
--- a/cocas/assembler/ast_builder.py
+++ b/cocas/assembler/ast_builder.py
@@ -308,6 +308,8 @@ class BuildAstVisitor(AsmParserVisitor):
                 result = result_
             else:
                 result = codecs.encode(result_, "utf-8")
+        except ValueError as e:
+            raise AssemblerException(AssemblerExceptionTag.ASM, loc.file, loc.line, str(e))
         except DeprecationWarning as e:
             raise AssemblerException(AssemblerExceptionTag.ASM, loc.file, loc.line, str(e))
         except UnicodeDecodeError as e:


### PR DESCRIPTION
This PR makes `cocas` output a proper error instead of a traceback when trying to parse invalid escape codes such as these:

```asm
asect 0
dc "\xA"
dc "\400"
end
```